### PR TITLE
Initial Fio Promo outline

### DIFF
--- a/src/bin/fioPromo/fioLookup.ts
+++ b/src/bin/fioPromo/fioLookup.ts
@@ -58,12 +58,9 @@ export async function filterDomain( // Test
 
   for (const tx of fioList) {
     const { payoutAddress } = tx
-    // console.log(`Payout address is: ${payoutAddress}`)
-    if (payoutAddress == null) continue
-    const result = await checkDomain(payoutAddress)
 
-    // console.log(`Checking address: ${payoutAddress}`)
-    // console.log(`Result: ${result}`)
+    if (payoutAddress == null) continue
+    const result = await checkDomain(payoutAddress, domain)
 
     if (result) txList.push(tx)
   }
@@ -77,8 +74,6 @@ export const checkDomain = async (
   domain: string = DEFAULT_DOMAIN, // By default check for @edge domains
   network: string = NETWORK
 ): Promise<boolean> => {
-  // console.log(`Pubkey to check: ${pubkey}`)
-
   const endPoint = '/get_fio_names'
 
   // const tapiUrl = testNet + endPoint
@@ -89,7 +84,6 @@ export const checkDomain = async (
   })
 
   const fioInfo = await result.json()
-  // console.log(Object.entries(fioInfo).toString())
 
   if (
     Object.entries(fioInfo)
@@ -101,7 +95,7 @@ export const checkDomain = async (
   } else {
     const fioNames = asGetFioNames(fioInfo)
 
-    // console.log(fioNames)
+
 
     for (const fioName of fioNames.fio_addresses) {
       const cleanFioName = asFioAddress(fioName)
@@ -140,7 +134,6 @@ export const getRewards = (
     }
   }
 
-  // console.log(`The mapped results are: ${rewards}`)
 
   return rewards
 }

--- a/src/bin/fioPromo/fioLookup.ts
+++ b/src/bin/fioPromo/fioLookup.ts
@@ -1,0 +1,93 @@
+import { asArray, asObject, asString, asUnknown } from 'cleaners'
+import fetch from 'node-fetch'
+
+import { queryChangeNow } from '../../partners/changenow'
+import { PluginParams, StandardTx } from '../../types'
+const asGetFioNames = asObject({
+  fio_addresses: asArray(asUnknown)
+})
+const asFioAddress = asObject({
+  fio_address: asString
+})
+
+const noNamesMessage: string = 'No FIO names'
+
+// Returns all customers from ChangeNow who have purchased FIO
+export async function getFioCustomers(checkFrom): Promise<StandardTx[]> {
+  // Get public keys from offset
+  const config: PluginParams = {
+    settings: {
+      offset: checkFrom
+    },
+    apiKeys: {
+      changenowApiKey:
+        '19556aef5cd0a1e8090d30540f93b456b76cda1aecf2c864cb66d89b7815c941'
+    }
+  }
+
+  const txnList = await queryChangeNow(config)
+
+  // Return list of Fio Customers
+  return txnList.transactions.filter(
+    transaction => transaction.payoutCurrency === 'FIO'
+  )
+}
+
+export async function filterEdgeDomains(
+  fioList: StandardTx[]
+): Promise<string[]> {
+  const domainList: string[] = []
+
+  for (const { payoutAddress } of fioList) {
+    console.log(`Payout address is: ${payoutAddress}`)
+    if (payoutAddress == null) continue
+    const result = await checkDomain(payoutAddress)
+
+    console.log(`Checking address: ${payoutAddress}`)
+    console.log(`Result: ${result}`)
+
+    if (result) domainList.push(payoutAddress)
+  }
+  return domainList // only FIO addresses with an @edge Fio domain
+}
+
+// Does FIO public address have specified domain?
+export const checkDomain = async (
+  pubkey: string | undefined,
+  domain: string | undefined = 'edge' // By default check for @edge domains
+): Promise<boolean> => {
+  console.log(`Pubkey to check: ${pubkey}`)
+
+  const apiUrl: string = 'http://testnet.fioprotocol.io/v1/chain/get_fio_names'
+  // const mainNet = 'https://reg.fioprotocol.io/public-api/'
+  const result = (
+    await fetch(`${apiUrl}`, {
+      method: 'POST',
+      body: JSON.stringify({ fio_public_key: pubkey })
+    })
+  ).json() // Get body
+
+  console.log(Object.entries(await result))
+  console.log(Object.entries(await result).toString())
+
+  if (
+    Object.entries(await result)
+      .toString()
+      .includes(noNamesMessage)
+  ) {
+    // No FIO names
+    return false
+  } else {
+    const fioNames = asGetFioNames(await result)
+
+    console.log(fioNames)
+
+    for (const fioName of fioNames.fio_addresses) {
+      const cleanFioName = asFioAddress(fioName)
+      if (cleanFioName.fio_address.includes(`@${domain}`)) {
+        return true
+      }
+    }
+    return false
+  }
+}

--- a/src/bin/fioPromo/fioPromo.ts
+++ b/src/bin/fioPromo/fioPromo.ts
@@ -1,0 +1,47 @@
+import { checkDomain, filterEdgeDomains, getFioCustomers } from './fioLookup'
+
+const testAddress = ['FIO5MctVjvoTiEFPyJYNnPerAXHWRUhDe2ZNEDCj43ngU4W5jZXzA']
+const test = async (): Promise<void> => {
+  // Write one case that works, and one that doesn't
+  // Try to use different prompts
+  // getFioCustomers()
+  // filterEdgeDomains()
+  // checkAddress()
+  // Unit tests
+  const expectedResult = await checkDomain(testAddress[0], 'fiotestnet')
+  console.log(expectedResult)
+  if (expectedResult !== true) throw new Error(`Check Domain ${testAddress[0]}`)
+
+  // const expectedResult2 = await checkAddress(testAddress[1])
+  // console.log(expectedResult2)
+  // if (expectedResult2 !== true) throw new Error(`Check Address ${testAddress[1]}`)
+}
+
+async function main(): Promise<null> {
+  await test()
+
+  // 1. Get offset from user
+
+  let checkFrom = parseInt(process.argv.slice(2)[0])
+  checkFrom = isNaN(checkFrom) ? 135000 : checkFrom // If null, set default to
+
+  console.log(`Checking from: ${checkFrom}`)
+
+  // 2. Get customers in specified time-frame
+  const fioCustomers = await getFioCustomers(checkFrom)
+
+  console.log(`Number of FIO customers: ${fioCustomers.length}`)
+  console.log(`Fio customers: ${JSON.stringify(fioCustomers)}`)
+
+  // 3. Check for @edge domains
+  const edgeAccounts = await filterEdgeDomains(fioCustomers)
+  console.log(edgeAccounts)
+
+  // 4. Apply Limits
+
+  // 5. Send money
+
+  return null
+}
+
+main().catch(e => console.log(e))

--- a/src/bin/fioPromo/fioPromo.ts
+++ b/src/bin/fioPromo/fioPromo.ts
@@ -1,4 +1,12 @@
-import { checkDomain, filterEdgeDomains, getFioCustomers } from './fioLookup'
+import { StandardTx } from '../../types'
+import {
+  checkDomain,
+  filterDomain,
+  getFioTransactions,
+  getRewards
+} from './fioLookup'
+
+const DEFAULT_OFFSET = 135000 // Latest is 139000
 
 const testAddress = [
   'FIO5MctVjvoTiEFPyJYNnPerAXHWRUhDe2ZNEDCj43ngU4W5jZXzA',
@@ -13,12 +21,56 @@ const test = async (): Promise<void> => {
   // Unit tests
   const expectedResult = await checkDomain(testAddress[0], 'fiotestnet')
   console.log(expectedResult)
-  if (expectedResult !== true) throw new Error(`Check Domain ${testAddress[0]}`)
+  if (expectedResult !== false)
+    throw new Error(`Check Domain ${testAddress[0]}`)
 
   const expectedResult2 = await checkDomain(testAddress[1])
   console.log(expectedResult2)
   if (expectedResult2 !== false)
     throw new Error(`Check Address ${testAddress[1]}`)
+
+  // Test getRewards()
+  // Example Standard Tx
+  const tPayoutAddresses: StandardTx[] = [
+    {
+      status: 'complete',
+      orderId:
+        'a8b6d763d35d3b753fb987493adef15c3d5d47b77b7e98e0fb2aefacff7ddc81',
+      depositTxid:
+        'a8b6d763d35d3b753fb987493adef15c3d5d47b77b7e98e0fb2aefacff7ddc81',
+      depositAddress: 'qp3xryh97c7wnqyz0k5csc38fuwa2m3acszwvurnuf',
+      depositCurrency: 'BCH',
+      depositAmount: 0.13699,
+      payoutTxid:
+        '7fa2600f4b14a7e7b093e4ec3d65a9409681de6b48a26b5559e89b31b9eead58',
+      payoutAddress: 'FIO8bToxvXGj1kK2W5yQoTxvhbrHRRtXu8EHokoaeB9mb9NFrAXu9',
+      payoutCurrency: 'FIO',
+      payoutAmount: 124.40797699,
+      timestamp: 1598908235.759,
+      isoDate: '2020-08-31T21:10:35.759Z',
+      usdValue: undefined,
+      rawTx: {
+        status: 'finished',
+        payinHash:
+          'a8b6d763d35d3b753fb987493adef15c3d5d47b77b7e98e0fb2aefacff7ddc81',
+        payoutHash:
+          '7fa2600f4b14a7e7b093e4ec3d65a9409681de6b48a26b5559e89b31b9eead58',
+        payinAddress: 'qp3xryh97c7wnqyz0k5csc38fuwa2m3acszwvurnuf',
+        payoutAddress: 'FIO8bToxvXGj1kK2W5yQoTxvhbrHRRtXu8EHokoaeB9mb9NFrAXu9',
+        fromCurrency: 'bch',
+        toCurrency: 'fio',
+        amountSend: 0.13699,
+        amountReceive: 124.40797699,
+        refundAddress: '1Q2ELFFGHSRTBsu5iyy7SsPHzxTn3EF91s',
+        id: '448d034310d690',
+        updatedAt: '2020-08-31T21:10:35.759Z'
+      }
+    }
+  ]
+
+  console.log(getRewards(tPayoutAddresses))
+
+
 }
 
 async function main(): Promise<null> {
@@ -26,23 +78,25 @@ async function main(): Promise<null> {
 
   // 1. Get offset from user
 
-  let checkFrom = parseInt(process.argv.slice(2)[0])
-  checkFrom = isNaN(checkFrom) ? 135000 : checkFrom // If null, set default to
+  let checkFrom = parseInt(process.argv[2]) // Getting first arg from
+  console.log(checkFrom)
+  checkFrom = isNaN(checkFrom) ? DEFAULT_OFFSET : checkFrom // If null, set to default
 
   console.log(`Checking from: ${checkFrom}`)
 
   // 2. Get FIO customers in specified time-frame
-  const fioCustomers = await getFioCustomers(checkFrom)
+  const fioTransactions = await getFioTransactions(checkFrom)
 
-  console.log(`Number of FIO customers: ${fioCustomers.length}`)
-  console.log(`Fio customers: ${JSON.stringify(fioCustomers)}`)
+  console.log(`Number of FIO transactions: ${fioTransactions.length}`)
+  console.log(`Fio transactions: ${JSON.stringify(fioTransactions)}`)
 
   // 3. Filter for @edge domains
-  const edgeAccounts = await filterEdgeDomains(fioCustomers)
-  console.log(edgeAccounts)
+  const edgeFioTransactions = await filterDomain(fioTransactions, 'edge')
+  console.log(edgeFioTransactions)
 
   // 4. Add up purchases up to 40 FIO
-  // const
+  const rewards = getRewards(edgeFioTransactions)
+  console.log(`Rewards are: ${JSON.stringify(rewards)}`)
 
   // 5. Send money
 

--- a/src/bin/fioPromo/fioPromo.ts
+++ b/src/bin/fioPromo/fioPromo.ts
@@ -1,6 +1,9 @@
 import { checkDomain, filterEdgeDomains, getFioCustomers } from './fioLookup'
 
-const testAddress = ['FIO5MctVjvoTiEFPyJYNnPerAXHWRUhDe2ZNEDCj43ngU4W5jZXzA']
+const testAddress = [
+  'FIO5MctVjvoTiEFPyJYNnPerAXHWRUhDe2ZNEDCj43ngU4W5jZXzA',
+  'FIO8TPpos3a8TVp9k4KaByrTw5sh2N1QuS4ro4gc4ooBczEPvTNNU'
+]
 const test = async (): Promise<void> => {
   // Write one case that works, and one that doesn't
   // Try to use different prompts
@@ -12,9 +15,10 @@ const test = async (): Promise<void> => {
   console.log(expectedResult)
   if (expectedResult !== true) throw new Error(`Check Domain ${testAddress[0]}`)
 
-  // const expectedResult2 = await checkAddress(testAddress[1])
-  // console.log(expectedResult2)
-  // if (expectedResult2 !== true) throw new Error(`Check Address ${testAddress[1]}`)
+  const expectedResult2 = await checkDomain(testAddress[1])
+  console.log(expectedResult2)
+  if (expectedResult2 !== false)
+    throw new Error(`Check Address ${testAddress[1]}`)
 }
 
 async function main(): Promise<null> {
@@ -27,17 +31,18 @@ async function main(): Promise<null> {
 
   console.log(`Checking from: ${checkFrom}`)
 
-  // 2. Get customers in specified time-frame
+  // 2. Get FIO customers in specified time-frame
   const fioCustomers = await getFioCustomers(checkFrom)
 
   console.log(`Number of FIO customers: ${fioCustomers.length}`)
   console.log(`Fio customers: ${JSON.stringify(fioCustomers)}`)
 
-  // 3. Check for @edge domains
+  // 3. Filter for @edge domains
   const edgeAccounts = await filterEdgeDomains(fioCustomers)
   console.log(edgeAccounts)
 
-  // 4. Apply Limits
+  // 4. Add up purchases up to 40 FIO
+  // const
 
   // 5. Send money
 

--- a/src/bin/fioPromo/fioPromo.ts
+++ b/src/bin/fioPromo/fioPromo.ts
@@ -1,6 +1,4 @@
-import { StandardTx } from '../../types'
 import {
-  checkDomain,
   filterDomain,
   getFioTransactions,
   getRewards
@@ -8,76 +6,8 @@ import {
 
 const DEFAULT_OFFSET = 135000 // Latest is 139000
 
-const testAddress = [
-  'FIO5MctVjvoTiEFPyJYNnPerAXHWRUhDe2ZNEDCj43ngU4W5jZXzA',
-  'FIO8TPpos3a8TVp9k4KaByrTw5sh2N1QuS4ro4gc4ooBczEPvTNNU'
-]
-const test = async (): Promise<void> => {
-  // Write one case that works, and one that doesn't
-  // Try to use different prompts
-  // getFioCustomers()
-  // filterEdgeDomains()
-  // checkAddress()
-  // Unit tests
-  const expectedResult = await checkDomain(testAddress[0], 'fiotestnet')
-  console.log(expectedResult)
-  if (expectedResult !== false)
-    throw new Error(`Check Domain ${testAddress[0]}`)
-
-  const expectedResult2 = await checkDomain(testAddress[1])
-  console.log(expectedResult2)
-  if (expectedResult2 !== false)
-    throw new Error(`Check Address ${testAddress[1]}`)
-
-  // Test getRewards()
-  // Example Standard Tx
-  const tPayoutAddresses: StandardTx[] = [
-    {
-      status: 'complete',
-      orderId:
-        'a8b6d763d35d3b753fb987493adef15c3d5d47b77b7e98e0fb2aefacff7ddc81',
-      depositTxid:
-        'a8b6d763d35d3b753fb987493adef15c3d5d47b77b7e98e0fb2aefacff7ddc81',
-      depositAddress: 'qp3xryh97c7wnqyz0k5csc38fuwa2m3acszwvurnuf',
-      depositCurrency: 'BCH',
-      depositAmount: 0.13699,
-      payoutTxid:
-        '7fa2600f4b14a7e7b093e4ec3d65a9409681de6b48a26b5559e89b31b9eead58',
-      payoutAddress: 'FIO8bToxvXGj1kK2W5yQoTxvhbrHRRtXu8EHokoaeB9mb9NFrAXu9',
-      payoutCurrency: 'FIO',
-      payoutAmount: 124.40797699,
-      timestamp: 1598908235.759,
-      isoDate: '2020-08-31T21:10:35.759Z',
-      usdValue: undefined,
-      rawTx: {
-        status: 'finished',
-        payinHash:
-          'a8b6d763d35d3b753fb987493adef15c3d5d47b77b7e98e0fb2aefacff7ddc81',
-        payoutHash:
-          '7fa2600f4b14a7e7b093e4ec3d65a9409681de6b48a26b5559e89b31b9eead58',
-        payinAddress: 'qp3xryh97c7wnqyz0k5csc38fuwa2m3acszwvurnuf',
-        payoutAddress: 'FIO8bToxvXGj1kK2W5yQoTxvhbrHRRtXu8EHokoaeB9mb9NFrAXu9',
-        fromCurrency: 'bch',
-        toCurrency: 'fio',
-        amountSend: 0.13699,
-        amountReceive: 124.40797699,
-        refundAddress: '1Q2ELFFGHSRTBsu5iyy7SsPHzxTn3EF91s',
-        id: '448d034310d690',
-        updatedAt: '2020-08-31T21:10:35.759Z'
-      }
-    }
-  ]
-
-  console.log(getRewards(tPayoutAddresses))
-
-
-}
-
 async function main(): Promise<null> {
-  await test()
-
   // 1. Get offset from user
-
   let checkFrom = parseInt(process.argv[2]) // Getting first arg from
   console.log(checkFrom)
   checkFrom = isNaN(checkFrom) ? DEFAULT_OFFSET : checkFrom // If null, set to default

--- a/test/fioPromo.test.ts
+++ b/test/fioPromo.test.ts
@@ -1,0 +1,74 @@
+import { expect } from 'chai'
+import { describe, it } from 'mocha'
+
+import { checkDomain, getRewards } from '../src/bin/fioPromo/fioLookup'
+
+const testAddress: Array<[string,boolean]> = [
+  ['FIO5MctVjvoTiEFPyJYNnPerAXHWRUhDe2ZNEDCj43ngU4W5jZXzA', false],
+  ['FIO8TPpos3a8TVp9k4KaByrTw5sh2N1QuS4ro4gc4ooBczEPvTNNU', false]
+]
+
+const fixtures = {
+  getRewards: {
+    data: [
+      {
+        status: 'complete',
+        orderId:
+          'a8b6d763d35d3b753fb987493adef15c3d5d47b77b7e98e0fb2aefacff7ddc81',
+        depositTxid:
+          'a8b6d763d35d3b753fb987493adef15c3d5d47b77b7e98e0fb2aefacff7ddc81',
+        depositAddress: 'qp3xryh97c7wnqyz0k5csc38fuwa2m3acszwvurnuf',
+        depositCurrency: 'BCH',
+        depositAmount: 0.13699,
+        payoutTxid:
+          '7fa2600f4b14a7e7b093e4ec3d65a9409681de6b48a26b5559e89b31b9eead58',
+        payoutAddress: 'FIO8bToxvXGj1kK2W5yQoTxvhbrHRRtXu8EHokoaeB9mb9NFrAXu9',
+        payoutCurrency: 'FIO',
+        payoutAmount: 124.40797699,
+        timestamp: 1598908235.759,
+        isoDate: '2020-08-31T21:10:35.759Z',
+        usdValue: undefined,
+        rawTx: {
+          status: 'finished',
+          payinHash:
+            'a8b6d763d35d3b753fb987493adef15c3d5d47b77b7e98e0fb2aefacff7ddc81',
+          payoutHash:
+            '7fa2600f4b14a7e7b093e4ec3d65a9409681de6b48a26b5559e89b31b9eead58',
+          payinAddress: 'qp3xryh97c7wnqyz0k5csc38fuwa2m3acszwvurnuf',
+          payoutAddress: 'FIO8bToxvXGj1kK2W5yQoTxvhbrHRRtXu8EHokoaeB9mb9NFrAXu9',
+          fromCurrency: 'bch',
+          toCurrency: 'fio',
+          amountSend: 0.13699,
+          amountReceive: 124.40797699,
+          refundAddress: '1Q2ELFFGHSRTBsu5iyy7SsPHzxTn3EF91s',
+          id: '448d034310d690',
+          updatedAt: '2020-08-31T21:10:35.759Z'
+        }
+      }
+    ],
+    expected: {
+      "FIO8bToxvXGj1kK2W5yQoTxvhbrHRRtXu8EHokoaeB9mb9NFrAXu9": 40,/*
+      "FIO8gcjB4tTfTHvjWjc1RQwLGpxk8vCzbxZujhiPvURx527xVrEkS": 40,
+      "FIO6oPCnk7SNSnAAXFM1nS1qv8kNsBXnaHLXDfMBjEh6r2U3kQ5PY": 40,
+      "FIO7vXvbZnkAodCj8Huw4dhFiu4VkPaTexpvLcxJVQmU2CtfzkAoD": 40 // Personal test address*/
+    }
+    }
+  }
+
+
+
+describe('Checking if address has Edge domain', function () {
+  for (const fixture of testAddress) {
+    it(`Check FIO public address: ${fixture[0]}`, async function () {
+      const result = await checkDomain(fixture[0], 'fiotestnet')
+      expect(result).equals(fixture[1])
+    })
+  }
+})
+
+describe('Checking rewards function', function () {
+    it(`Check reward for single transaction`, function () {
+      expect(getRewards(fixtures.getRewards.data)).to.deep.
+        equals(fixtures.getRewards.expected)
+    })
+})


### PR DESCRIPTION
All pre-commit checks cleared except typescript's build.

Temporarily disabled the following in package.json (not committed)
`"build.types": "tsc",`

Will resolve later.

For now, I've added Mainnet API URLs to verify FIO customers have @edge domains on mainnet and some basic handling of errors.

Will add some example FIO addresses I made test purchases of FIO with changeNow partner.