### PR TITLE
Thomas/partner fixes

### DIFF
--- a/src/partners/bitrefill.ts
+++ b/src/partners/bitrefill.ts
@@ -9,9 +9,9 @@ import {
   asUnknown
 } from 'cleaners'
 import fetch from 'node-fetch'
-import { datelog } from '../util'
 
 import { PartnerPlugin, PluginParams, PluginResult, StandardTx } from '../types'
+import { datelog } from '../util'
 
 const asBitrefillTx = asObject({
   paymentReceived: asBoolean,
@@ -25,6 +25,10 @@ const asBitrefillTx = asObject({
   receivedPaymentAltcoin: asOptional(asNumber),
   orderId: asString,
   usdPrice: asNumber
+})
+
+const asRawBitrefillTx = asObject({
+  status: asString
 })
 
 const asBitrefillResult = asObject({
@@ -80,6 +84,9 @@ export async function queryBitrefill(
     }
     const txs = jsonObj.orders
     for (const rawtx of txs) {
+      if (asRawBitrefillTx(rawtx).status === 'unpaid') {
+        continue
+      }
       const tx = asBitrefillTx(rawtx)
       if (
         tx.paymentReceived === true &&

--- a/src/partners/transak.ts
+++ b/src/partners/transak.ts
@@ -4,13 +4,14 @@ import {
   asEither,
   asNumber,
   asObject,
+  asOptional,
   asString,
   asUnknown
 } from 'cleaners'
 import fetch from 'node-fetch'
-import { datelog } from '../util'
 
 import { PartnerPlugin, PluginParams, PluginResult, StandardTx } from '../types'
+import { datelog } from '../util'
 
 const PAGE_LIMIT = 100
 const OFFSET_ROLLBACK = 500
@@ -18,7 +19,7 @@ const OFFSET_ROLLBACK = 500
 const asTransakOrder = asObject({
   status: asString,
   id: asString,
-  fromWalletAddress: asEither(asBoolean, asString),
+  fromWalletAddress: asOptional(asEither(asBoolean, asString)),
   fiatCurrency: asString,
   fiatAmount: asNumber,
   walletAddress: asString,


### PR DESCRIPTION
Bitrefill coincurrency field can be undefined if status is 'unpaid'

Transak fromWalletAddress field can be undefined, false, or string.  (old code only checked for false or string)