### PR TITLE
Reset offset to 0 SideShift.ai plugin

### DIFF
--- a/src/partners/sideshift.ts
+++ b/src/partners/sideshift.ts
@@ -132,7 +132,7 @@ export async function querySideshift(
   }
 
   return {
-    settings: { lastCheckedTimestamp: prevMaxTimestamp, offset },
+    settings: { lastCheckedTimestamp: prevMaxTimestamp, offset: 0 },
     transactions: txs
   }
 }


### PR DESCRIPTION
Since new transactions are near 0 `offset`, it doesn't make sense to save the last `offset` and start from there on the next run. This PR resets the `offset` to 0 after each run.