### PR TITLE
Allen/fix partner queries

### DIFF
--- a/src/partners/totle.ts
+++ b/src/partners/totle.ts
@@ -3,8 +3,8 @@ import { asArray, asNumber, asObject, asString, asUnknown } from 'cleaners'
 import fetch from 'node-fetch'
 import Web3 from 'web3'
 
-import { datelog } from '../util'
 import { PartnerPlugin, PluginParams, PluginResult, StandardTx } from '../types'
+import { datelog } from '../util'
 
 const asCurrentBlockResult = asNumber
 
@@ -294,14 +294,12 @@ const PRIMARY_ABI: any = [
     type: 'function'
   }
 ]
-const PARITY_NODE_WEBSOCKET = 'wss://node.totlesystem.com'
-const web3 = new Web3(
-  new Web3.providers.WebsocketProvider(PARITY_NODE_WEBSOCKET)
-)
 
 export async function queryTotle(
   pluginParams: PluginParams
 ): Promise<PluginResult> {
+  const nodeEndpoint = pluginParams.apiKeys.nodeEndpoint // Grab node endpoint from 'reports_apps' database
+  const web3 = new Web3(nodeEndpoint) // Create new Web3 instance using node endpoint
   const ssFormatTxs: StandardTx[] = []
   let partnerContractAddress
   let offset = 7000000

--- a/src/partners/transak.ts
+++ b/src/partners/transak.ts
@@ -56,7 +56,7 @@ export async function queryTransak(
   let done = false
 
   while (!done) {
-    const url = `https://api.transak.com/api/v1/partners/orders/?partnerAPISecret=${apiKey}&limit=${PAGE_LIMIT}&skip=${offset}`
+    const url = `https://api.transak.com/api/v2/partners/orders/?partnerAPISecret=${apiKey}&limit=${PAGE_LIMIT}&skip=${offset}`
     try {
       const result = await fetch(url)
       resultJSON = asTransakResult(await result.json())


### PR DESCRIPTION
Resolved issues with querying transaction history for two partner plugins: Totle and Transak.

1. Totle's Websocket node is deprecated. Changing to a https node endpoint that will be retrieved from `reports_apps` database. Please image below for reference.
![totle-reports_apps-2021-05-28](https://user-images.githubusercontent.com/52480474/120048439-f2efcc00-bfcb-11eb-98a8-e2d23b623bfe.png)
2. API for Transak is now `v2`.
