### PR TITLE
Allen/quarterly graph fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "commander": "^6.1.0",
     "cors": "^2.8.5",
     "date-fns": "^2.16.1",
+    "date-fns-tz": "^1.1.4",
     "express": "^4.17.1",
     "nano": "^8.2.2",
     "node-fetch": "^2.6.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2892,6 +2892,11 @@ data-urls@^1.1.0:
     whatwg-mimetype "^2.2.0"
     whatwg-url "^7.0.0"
 
+date-fns-tz@^1.1.4:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/date-fns-tz/-/date-fns-tz-1.1.4.tgz#38282c2bfab08946a4e9bb89d733451e5525048b"
+  integrity sha512-lQ+FF7xUxxRuRqIY7H/lagnT3PhhSnnvtGHzjE5WZKwRyLU7glJfLys05SZ7zHlEr6RXWiqkmgWq4nCkcElR+g==
+
 date-fns@^2.0.1:
   version "2.15.0"
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.15.0.tgz#424de6b3778e4e69d3ff27046ec136af58ae5d5f"


### PR DESCRIPTION
Quarterly graph on the `reports` server shows an additional empty bucket. Issue can be traced back to how JavaScript calculates the timezone offset, which may be +/- 60 minutes depending on daylight savings time (DST). Updated the `util` file to use `date-fns-tz` to find timezone offset, which is more accurate.