### PR TITLE
Fix cache with deleted entries

### DIFF
--- a/src/cacheEngine.ts
+++ b/src/cacheEngine.ts
@@ -147,7 +147,8 @@ export async function cacheEngine(): Promise<void> {
               })
               const _revs = await database.fetchRevs({ keys: documentIds })
               for (let i = 0; i < _revs.rows.length; i++) {
-                if (_revs.rows[i].error == null) {
+                if (_revs.rows[i].error == null &&
+                  _revs.rows[i].value.deleted !== true) {
                   cacheResult[i]._rev = _revs.rows[i].value.rev
                 }
               }


### PR DESCRIPTION
The report server cache does not properly update the database when there are deleted entries in the database. This fix properly detects deleted entries and leaves the REV blank to properly update the database