### PR TITLE
Properly handle nulls in number type fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - added: Paybis support
 - changed: Paginate caching engine to prevent timeouts
 - changed: Create caching engine 'initialized' document entry for each app:partner pair
+- fixed: Properly handle null values in 'number' typed fields
 
 ## 0.1.0
 

--- a/src/bin/bogReporter.ts
+++ b/src/bin/bogReporter.ts
@@ -1,6 +1,7 @@
 import fetch from 'node-fetch'
 
 import { config } from '../config'
+import { safeParseFloat } from '../util'
 
 const BITS_OF_GOLD_API_KEY = config.bog.apiKey
 
@@ -74,7 +75,7 @@ async function queryFiatRate(
     throw new Error(`queryFiatRate failed with status code ${result.status}`)
   }
   const json = await result.json()
-  return parseFloat(json.exchangeRate)
+  return safeParseFloat(json.exchangeRate)
 }
 
 async function queryCryptoRate(
@@ -91,7 +92,7 @@ async function queryCryptoRate(
     throw new Error(`queryCryptoRate failed with status code ${result.status}`)
   }
   const json = await result.json()
-  return parseFloat(json.exchangeRate)
+  return safeParseFloat(json.exchangeRate)
 }
 
 queryBog().catch(e => console.log(e))

--- a/src/bin/migration.ts
+++ b/src/bin/migration.ts
@@ -15,7 +15,7 @@ import nano from 'nano'
 
 import { pagination } from '../dbutils'
 import { DbTx, StandardTx } from '../types'
-import { datelog } from '../util'
+import { datelog, safeParseFloat } from '../util'
 
 const config = js.readFileSync('./config.json')
 
@@ -143,7 +143,9 @@ async function migration(): Promise<void> {
                   payoutTxid: cleanedShapeshiftTx.outputTXID,
                   payoutAddress: cleanedShapeshiftTx.outputAddress,
                   payoutCurrency: cleanedShapeshiftTx.outputCurrency,
-                  payoutAmount: parseFloat(cleanedShapeshiftTx.outputAmount),
+                  payoutAmount: safeParseFloat(
+                    cleanedShapeshiftTx.outputAmount
+                  ),
                   timestamp: cleanedShapeshiftTx.timestamp,
                   isoDate: new Date(
                     cleanedShapeshiftTx.timestamp * 1000
@@ -161,7 +163,7 @@ async function migration(): Promise<void> {
               const timestamp =
                 typeof cleanedOldTx.timestamp === 'number'
                   ? cleanedOldTx.timestamp
-                  : parseFloat(cleanedOldTx.timestamp)
+                  : safeParseFloat(cleanedOldTx.timestamp)
               const isoDate = new Date(timestamp * 1000).toISOString()
               const depositAddress =
                 typeof cleanedOldTx.inputAddress === 'string' &&
@@ -175,11 +177,11 @@ async function migration(): Promise<void> {
               const depositAmount =
                 typeof cleanedOldTx.inputAmount === 'number'
                   ? cleanedOldTx.inputAmount
-                  : parseFloat(cleanedOldTx.inputAmount)
+                  : safeParseFloat(cleanedOldTx.inputAmount)
               const payoutAmount =
                 typeof cleanedOldTx.outputAmount === 'number'
                   ? cleanedOldTx.outputAmount
-                  : parseFloat(cleanedOldTx.outputAmount)
+                  : safeParseFloat(cleanedOldTx.outputAmount)
               const newTx: StandardTx = {
                 orderId: cleanedOldTx.inputTXID,
                 depositTxid: undefined,

--- a/src/bin/partnerTotals.ts
+++ b/src/bin/partnerTotals.ts
@@ -7,7 +7,7 @@ import fetch from 'node-fetch'
 // import fetch from 'node-fetch'
 import config from '../../config.json'
 import { asDbTx, DbTx } from '../types'
-import { datelog, standardizeNames } from '../util'
+import { datelog, safeParseFloat, standardizeNames } from '../util'
 
 const nanoDb = nano(config.couchDbFullpath)
 const QUERY_LIMIT = 100
@@ -201,7 +201,7 @@ async function getExchangeRate(
     datelog(
       `Rate for ${currencyA} -> ${currencyB} ${date}: ${jsonObj.exchangeRate}`
     )
-    return parseFloat(jsonObj.exchangeRate)
+    return safeParseFloat(jsonObj.exchangeRate)
   } catch (e) {
     datelog(
       `Could not not get exchange rate for ${currencyA} and ${currencyB} at ${date}.`,

--- a/src/partners/bitrefill.ts
+++ b/src/partners/bitrefill.ts
@@ -11,7 +11,7 @@ import {
 import fetch from 'node-fetch'
 
 import { PartnerPlugin, PluginParams, PluginResult, StandardTx } from '../types'
-import { datelog } from '../util'
+import { datelog, safeParseFloat } from '../util'
 
 const asBitrefillTx = asObject({
   paymentReceived: asBoolean,
@@ -103,7 +103,7 @@ export async function queryBitrefill(
         if (inputAmountStr == null) {
           break
         }
-        const inputAmountNum = parseFloat(
+        const inputAmountNum = safeParseFloat(
           div(inputAmountStr, multipliers[inputCurrency], 8)
         )
         const ssTx: StandardTx = {

--- a/src/partners/bity.ts
+++ b/src/partners/bity.ts
@@ -2,7 +2,7 @@ import { asArray, asObject, asString, asUnknown } from 'cleaners'
 import fetch from 'node-fetch'
 
 import { PartnerPlugin, PluginParams, PluginResult, StandardTx } from '../types'
-import { datelog } from '../util'
+import { datelog, safeParseFloat } from '../util'
 
 const asBityTx = asObject({
   id: asString,
@@ -123,11 +123,11 @@ export async function queryBity(
           depositTxid: undefined,
           depositAddress: undefined,
           depositCurrency: tx.input.currency.toUpperCase(),
-          depositAmount: parseFloat(tx.input.amount),
+          depositAmount: safeParseFloat(tx.input.amount),
           payoutTxid: undefined,
           payoutAddress: undefined,
           payoutCurrency: tx.output.currency.toUpperCase(),
-          payoutAmount: parseFloat(tx.output.amount),
+          payoutAmount: safeParseFloat(tx.output.amount),
           timestamp: Date.parse(tx.timestamp_created.concat('Z')) / 1000,
           isoDate: new Date(tx.timestamp_created.concat('Z')).toISOString(),
           usdValue: -1,

--- a/src/partners/changehero.ts
+++ b/src/partners/changehero.ts
@@ -16,7 +16,12 @@ import {
   StandardTx,
   Status
 } from '../types'
-import { datelog, retryFetch, smartIsoDateFromTimestamp } from '../util'
+import {
+  datelog,
+  retryFetch,
+  safeParseFloat,
+  smartIsoDateFromTimestamp
+} from '../util'
 
 const asChangeHeroStatus = asMaybe(asValue('finished', 'expired'), 'other')
 
@@ -127,11 +132,11 @@ export async function queryChangeHero(
           depositTxid: tx.payinHash,
           depositAddress: tx.payinAddress,
           depositCurrency: tx.currencyFrom.toUpperCase(),
-          depositAmount: parseFloat(tx.amountFrom),
+          depositAmount: safeParseFloat(tx.amountFrom),
           payoutTxid: tx.payoutHash,
           payoutAddress: tx.payoutAddress,
           payoutCurrency: tx.currencyTo.toUpperCase(),
-          payoutAmount: parseFloat(tx.amountTo),
+          payoutAmount: safeParseFloat(tx.amountTo),
           timestamp: tx.createdAt,
           isoDate: smartIsoDateFromTimestamp(tx.createdAt).isoDate,
           usdValue: -1,

--- a/src/partners/changelly.ts
+++ b/src/partners/changelly.ts
@@ -2,7 +2,7 @@ import Changelly from 'api-changelly/lib.js'
 import { asArray, asNumber, asObject, asString, asUnknown } from 'cleaners'
 
 import { PartnerPlugin, PluginParams, PluginResult, StandardTx } from '../types'
-import { datelog } from '../util'
+import { datelog, safeParseFloat } from '../util'
 
 const asChangellyTx = asObject({
   id: asString,
@@ -138,11 +138,11 @@ export async function queryChangelly(
             depositTxid: tx.payinHash,
             depositAddress: tx.payinAddress,
             depositCurrency: tx.currencyFrom.toUpperCase(),
-            depositAmount: parseFloat(tx.amountFrom),
+            depositAmount: safeParseFloat(tx.amountFrom),
             payoutTxid: tx.payoutHash,
             payoutAddress: tx.payoutAddress,
             payoutCurrency: tx.currencyTo.toUpperCase(),
-            payoutAmount: parseFloat(tx.amountTo),
+            payoutAmount: safeParseFloat(tx.amountTo),
             timestamp: tx.createdAt,
             isoDate: new Date(tx.createdAt * 1000).toISOString(),
             usdValue: -1,

--- a/src/partners/godex.ts
+++ b/src/partners/godex.ts
@@ -15,7 +15,12 @@ import {
   StandardTx,
   Status
 } from '../types'
-import { datelog, retryFetch, smartIsoDateFromTimestamp } from '../util'
+import {
+  datelog,
+  retryFetch,
+  safeParseFloat,
+  smartIsoDateFromTimestamp
+} from '../util'
 
 const asGodexPluginParams = asObject({
   settings: asObject({
@@ -117,11 +122,11 @@ export async function queryGodex(
           depositTxid: tx.hash_in,
           depositAddress: tx.deposit,
           depositCurrency: tx.coin_from.toUpperCase(),
-          depositAmount: parseFloat(tx.deposit_amount),
+          depositAmount: safeParseFloat(tx.deposit_amount),
           payoutTxid: undefined,
           payoutAddress: tx.withdrawal,
           payoutCurrency: tx.coin_to.toUpperCase(),
-          payoutAmount: parseFloat(tx.withdrawal_amount),
+          payoutAmount: safeParseFloat(tx.withdrawal_amount),
           timestamp,
           isoDate,
           usdValue: -1,

--- a/src/partners/letsexchange.ts
+++ b/src/partners/letsexchange.ts
@@ -16,7 +16,12 @@ import {
   StandardTx,
   Status
 } from '../types'
-import { datelog, retryFetch, smartIsoDateFromTimestamp } from '../util'
+import {
+  datelog,
+  retryFetch,
+  safeParseFloat,
+  smartIsoDateFromTimestamp
+} from '../util'
 
 export const asLetsExchangePluginParams = asObject({
   settings: asObject({
@@ -126,11 +131,11 @@ export async function queryLetsExchange(
           depositTxid: tx.hash_in,
           depositAddress: tx.deposit,
           depositCurrency: tx.coin_from.toUpperCase(),
-          depositAmount: parseFloat(tx.deposit_amount),
+          depositAmount: safeParseFloat(tx.deposit_amount),
           payoutTxid: undefined,
           payoutAddress: tx.withdrawal,
           payoutCurrency: tx.coin_to.toUpperCase(),
-          payoutAmount: parseFloat(tx.withdrawal_amount),
+          payoutAmount: safeParseFloat(tx.withdrawal_amount),
           timestamp,
           isoDate,
           usdValue: -1,

--- a/src/partners/shapeshift.ts
+++ b/src/partners/shapeshift.ts
@@ -2,7 +2,7 @@ import { asArray, asNumber, asObject, asString, asUnknown } from 'cleaners'
 import fetch from 'node-fetch'
 
 import { PartnerPlugin, PluginParams, PluginResult, StandardTx } from '../types'
-import { datelog } from '../util'
+import { datelog, safeParseFloat } from '../util'
 
 const asShapeshiftTx = asObject({
   orderId: asString,
@@ -63,7 +63,7 @@ export async function queryShapeshift(
           payoutTxid: tx.outputTXID,
           payoutAddress: tx.outputAddress,
           payoutCurrency: tx.outputCurrency,
-          payoutAmount: parseFloat(tx.outputAmount),
+          payoutAmount: safeParseFloat(tx.outputAmount),
           timestamp: tx.timestamp,
           isoDate: new Date(tx.timestamp * 1000).toISOString(),
           usdValue: -1,

--- a/src/partners/simplex.ts
+++ b/src/partners/simplex.ts
@@ -11,6 +11,7 @@ import {
 } from 'cleaners'
 
 import { PartnerPlugin, PluginParams, PluginResult, StandardTx } from '../types'
+import { safeParseFloat } from '../util'
 
 const asSimplexTx = asObject({
   amount_usd: asString,
@@ -111,14 +112,14 @@ export async function querySimplex(
           depositTxid: undefined,
           depositAddress: undefined,
           depositCurrency: tx.currency,
-          depositAmount: parseFloat(tx.fiat_total_amount),
+          depositAmount: safeParseFloat(tx.fiat_total_amount),
           payoutTxid: undefined,
           payoutAddress: undefined,
           payoutCurrency: tx.crypto_currency,
-          payoutAmount: parseFloat(tx.amount_crypto),
+          payoutAmount: safeParseFloat(tx.amount_crypto),
           timestamp,
           isoDate: new Date(timestamp * 1000).toISOString(),
-          usdValue: parseFloat(tx.amount_usd),
+          usdValue: safeParseFloat(tx.amount_usd),
           rawTx
         }
         ssFormatTxs.push(ssTx)

--- a/src/partners/switchain.ts
+++ b/src/partners/switchain.ts
@@ -2,7 +2,7 @@ import { asArray, asObject, asString, asUnknown } from 'cleaners'
 import fetch from 'node-fetch'
 
 import { PartnerPlugin, PluginParams, PluginResult, StandardTx } from '../types'
-import { datelog } from '../util'
+import { datelog, safeParseFloat } from '../util'
 
 const asSwitchainTx = asObject({
   id: asString,
@@ -78,11 +78,11 @@ export async function querySwitchain(
           depositTxid: tx.depositTxId,
           depositAddress: tx.depositAddress,
           depositCurrency: pair[0].toUpperCase(),
-          depositAmount: parseFloat(tx.amountFrom),
+          depositAmount: safeParseFloat(tx.amountFrom),
           payoutTxid: tx.withdrawTxId,
           payoutAddress: tx.withdrawAddress,
           payoutCurrency: pair[1].toUpperCase(),
-          payoutAmount: parseFloat(tx.rate),
+          payoutAmount: safeParseFloat(tx.rate),
           timestamp: timestamp / 1000,
           isoDate: tx.createdAt,
           usdValue: -1,

--- a/src/partners/totle.ts
+++ b/src/partners/totle.ts
@@ -4,7 +4,7 @@ import fetch from 'node-fetch'
 import Web3 from 'web3'
 
 import { PartnerPlugin, PluginParams, PluginResult, StandardTx } from '../types'
-import { datelog } from '../util'
+import { datelog, safeParseFloat } from '../util'
 
 const asCurrentBlockResult = asNumber
 
@@ -393,7 +393,7 @@ export async function queryTotle(
             depositTxid: receipt.transactionHash,
             depositAddress: receipt.from,
             depositCurrency: sourceToken.symbol,
-            depositAmount: parseFloat(
+            depositAmount: safeParseFloat(
               div(
                 sourceAmount.toString(),
                 (10 ** sourceToken.decimals).toString(),
@@ -404,7 +404,7 @@ export async function queryTotle(
             payoutTxid: receipt.transactionHash,
             payoutAddress: receipt.to,
             payoutCurrency: destinationToken.symbol,
-            payoutAmount: parseFloat(
+            payoutAmount: safeParseFloat(
               div(
                 destinationAmount.toString(),
                 (10 ** destinationToken.decimals).toString(),

--- a/src/partners/wyre.ts
+++ b/src/partners/wyre.ts
@@ -2,6 +2,7 @@ import { asNumber, asObject, asOptional, asString } from 'cleaners'
 import fetch from 'node-fetch'
 
 import { PartnerPlugin, PluginParams, PluginResult, StandardTx } from '../types'
+import { safeParseFloat } from '../util'
 
 const asWyreTx = asObject({
   id: asString,
@@ -96,14 +97,14 @@ export async function queryWyre(
         depositTxid: undefined,
         depositAddress: undefined,
         depositCurrency: tx.sourceCurrency,
-        depositAmount: parseFloat(tx.sourceAmount),
+        depositAmount: safeParseFloat(tx.sourceAmount),
         payoutTxid: undefined,
         payoutAddress: undefined,
         payoutCurrency: tx.destCurrency,
-        payoutAmount: parseFloat(tx.destAmount),
+        payoutAmount: safeParseFloat(tx.destAmount),
         timestamp: dateMs / 1000,
         isoDate: date.toISOString(),
-        usdValue: parseFloat(tx.usdEquiv),
+        usdValue: safeParseFloat(tx.usdEquiv),
         rawTx: txStr
       }
 

--- a/src/ratesEngine.ts
+++ b/src/ratesEngine.ts
@@ -9,7 +9,7 @@ import {
   CurrencyCodeMappings,
   DbTx
 } from './types'
-import { datelog, standardizeNames } from './util'
+import { datelog, safeParseFloat, standardizeNames } from './util'
 
 const nanoDb = nano(config.couchDbFullpath)
 const QUERY_FREQ_MS = 15000
@@ -222,7 +222,7 @@ async function getExchangeRate(
     datelog(
       `Rate for ${currencyA} -> ${currencyB} ${date}: ${jsonObj.exchangeRate}`
     )
-    return parseFloat(jsonObj.exchangeRate)
+    return safeParseFloat(jsonObj.exchangeRate)
   } catch (e) {
     datelog(
       `Could not not get exchange rate for ${currencyA} and ${currencyB} at ${date}.`,

--- a/src/types.ts
+++ b/src/types.ts
@@ -38,16 +38,24 @@ const asStatus = asValue(
   'refunded',
   'other'
 )
+
+const asSafeNumber = (raw: any): number => {
+  if (isNaN(raw) || raw === null) {
+    return 0
+  }
+  return asNumber(raw)
+}
+
 const standardTxFields = {
   orderId: asString,
   depositTxid: asOptional(asString),
   depositAddress: asOptional(asString),
   depositCurrency: asString,
-  depositAmount: asNumber,
+  depositAmount: asSafeNumber,
   payoutTxid: asOptional(asString),
   payoutAddress: asOptional(asString),
   payoutCurrency: asString,
-  payoutAmount: asNumber,
+  payoutAmount: asSafeNumber,
   status: asStatus,
   isoDate: asString,
   timestamp: asNumber,

--- a/src/util.ts
+++ b/src/util.ts
@@ -122,3 +122,11 @@ export const getStartOfMonthsFromNow = (
   const month = date.getUTCMonth()
   return new Date(Date.UTC(year, month + months, 1, 0, 0, 0, 0))
 }
+
+/**
+ * Parses number strings, treating blank inputs as 0
+ */
+export const safeParseFloat = (val: string): number => {
+  if (val === '') return 0
+  return parseFloat(val)
+}


### PR DESCRIPTION
Null values can occur when empty strings ('') are sent to parseFloat which returns a NaN that when JSON.stringified returns a null.

Properly handle existing data that has a null by cleaning it into a 0 and also preventing nulls by cleaning empty strings into a 0 with safeParseFloat()

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [ ] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Description

<!-- Describe your changes textually and/or pictorially if necessary --> none


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207347933566203