### PR TITLE
Add signature header support to Exolix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- changed: Add signature header support to Exolix
 - changed: Add index for orderId
 - changed: Add EVM chainId, pluginId, and tokenId fields to StandardTx
 - changed: Update Lifi to provide chainId, pluginId, and tokenId

--- a/src/partners/exolix.ts
+++ b/src/partners/exolix.ts
@@ -30,7 +30,8 @@ const asExolixPluginParams = asObject({
     latestIsoDate: asOptional(asString, EXOLIX_START_DATE)
   }),
   apiKeys: asObject({
-    apiKey: asOptional(asString)
+    apiKey: asOptional(asString),
+    signature: asOptional(asString)
   })
 })
 
@@ -230,10 +231,10 @@ export async function queryExolix(
 ): Promise<PluginResult> {
   const { log } = pluginParams
   const { settings, apiKeys } = asExolixPluginParams(pluginParams)
-  const { apiKey } = apiKeys
+  const { apiKey, signature } = apiKeys
   let { latestIsoDate } = settings
 
-  if (apiKey == null) {
+  if (apiKey == null || signature == null) {
     return { settings: { latestIsoDate }, transactions: [] }
   }
 
@@ -252,7 +253,8 @@ export async function queryExolix(
         method: 'GET',
         headers: {
           'Content-Type': 'application/json',
-          Authorization: `${apiKey}`
+          Authorization: `${apiKey}`,
+          signature: `${signature}`
         }
       }
 


### PR DESCRIPTION
### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [ ] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Description

<!-- Describe your changes textually and/or pictorially if necessary --> none

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Partner sync stops until both apiKey and signature are configured; misconfiguration can silently yield empty Exolix transaction pulls.
> 
> **Overview**
> Exolix partner reporting now requires a **`signature`** credential alongside **`apiKey`**, and sends it on every Exolix API v2 transaction list request.
> 
> Plugin params validation accepts an optional `signature` in `apiKeys`. **`queryExolix`** returns no transactions (same as a missing API key) when either credential is absent, and adds a **`signature`** HTTP header next to **`Authorization`**. The unreleased changelog notes the change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7206b94ab39e5d4633ee1e7890bc337e99f715c2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1215305713887495