### PR TITLE
Load full ChangeNow currency list to resolve delisted assets

### DIFF
--- a/src/partners/changenow.ts
+++ b/src/partners/changenow.ts
@@ -143,8 +143,12 @@ async function loadCurrencyCache(
   }
 
   try {
-    // The exchange/currencies endpoint doesn't require authentication
-    const url = 'https://api.changenow.io/v2/exchange/currencies?active=true'
+    // The exchange/currencies endpoint doesn't require authentication.
+    // Fetch the full list (omit `active=true`): historical transactions can
+    // reference currencies that ChangeNow has since deactivated/delisted (e.g.
+    // DASH). Filtering to active-only drops those entries, causing a cache miss
+    // and a fail-closed halt on otherwise-valid historical transactions.
+    const url = 'https://api.changenow.io/v2/exchange/currencies'
     const response = await retryFetch(url, {
       method: 'GET'
     })


### PR DESCRIPTION
The currency cache was built from the `currencies?active=true` endpoint. When ChangeNow deactivates an asset (e.g. DASH), it disappears from the active list while historical transactions still reference it. The lookup then misses and the plugin halts fail-closed, stalling all ChangeNow transaction collection.

Fetch the full currency list (omit `active=true`) so previously-listed assets continue to resolve for historical transactions.

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [ ] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Description

<!-- Describe your changes textually and/or pictorially if necessary --> none

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single URL/query change in currency cache loading with no auth or schema changes; slightly larger cache payload is the main tradeoff.
> 
> **Overview**
> **ChangeNow currency cache** no longer filters to `active=true` when calling `exchange/currencies`. The plugin now loads the **full** currency list so tickers that ChangeNow has deactivated (e.g. DASH) still resolve when processing **historical** swaps.
> 
> Previously, a cache miss in `getAssetInfo` threw and stopped collection fail-closed for otherwise valid past transactions. Comments in `loadCurrencyCache` document that behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f3cd90d23cb9cbd946c3fb4ff155fd423475f827. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->