### PR TITLE
Add Swapter partner plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- added: Add Swapter reporting
 - changed: Update sideshift plugin with new optional API fields
 - changed: Add signature header support to Exolix
 - changed: Add index for orderId

--- a/src/partners/swapter.ts
+++ b/src/partners/swapter.ts
@@ -1,0 +1,237 @@
+import {
+  asArray,
+  asMaybe,
+  asNumber,
+  asObject,
+  asString,
+  asUnknown,
+  asValue
+} from 'cleaners'
+
+import {
+  asStandardPluginParams,
+  PartnerPlugin,
+  PluginParams,
+  PluginResult,
+  StandardTx,
+  Status
+} from '../types'
+import { retryFetch, smartIsoDateFromTimestamp, snooze } from '../util'
+
+const asSwapterStatus = asMaybe(
+  asValue(
+    'Waiting',
+    'Confirmation',
+    'Exchanging',
+    'Sending',
+    'Success',
+    'Frozen',
+    'Refunded',
+    'Overdue',
+    'Suspended'
+  ),
+  'other'
+)
+
+const asSwapterTx = asObject({
+  info: asObject({
+    uid: asString,
+    status: asSwapterStatus,
+    type: asString,
+    link: asString,
+    equivalent: asNumber
+  }),
+  deposit: asObject({
+    coin: asString,
+    network: asString,
+    amount: asNumber,
+    actual: asMaybe(asNumber),
+    address: asString,
+    memo: asMaybe(asString)
+  }),
+  withdraw: asObject({
+    coin: asString,
+    network: asString,
+    amount: asNumber,
+    address: asString,
+    memo: asMaybe(asString)
+  }),
+  time: asObject({
+    create: asNumber,
+    confirmation: asMaybe(asNumber),
+    exchanging: asMaybe(asNumber),
+    send: asMaybe(asNumber),
+    success: asMaybe(asNumber),
+    overdue: asMaybe(asNumber)
+  }),
+  partner: asObject({
+    name: asString,
+    profit: asObject({
+      amount: asNumber,
+      percent: asNumber
+    })
+  })
+})
+
+const asSwapterResult = asObject({
+  page: asNumber,
+  total: asNumber,
+  data: asArray(asUnknown)
+})
+
+type SwapterTx = ReturnType<typeof asSwapterTx>
+type SwapterStatus = ReturnType<typeof asSwapterStatus>
+
+const MAX_RETRIES = 5
+const LIMIT = 200
+const QUERY_LOOKBACK = 1000 * 60 * 60 * 24 * 5 // 5 days
+
+const statusMap: { [key in SwapterStatus]: Status } = {
+  Waiting: 'pending',
+  Confirmation: 'pending',
+  Exchanging: 'pending',
+  Sending: 'pending',
+  Success: 'complete',
+  Overdue: 'expired',
+  Refunded: 'refunded',
+  Frozen: 'other',
+  Suspended: 'other',
+  other: 'other'
+}
+
+export const querySwapter = async (
+  pluginParams: PluginParams
+): Promise<PluginResult> => {
+  const { log } = pluginParams
+  const { settings, apiKeys } = asStandardPluginParams(pluginParams)
+  const { apiKey } = apiKeys
+  let latestIsoDate =
+    typeof settings.latestIsoDate === 'string'
+      ? settings.latestIsoDate
+      : new Date(0).toISOString()
+
+  if (apiKey == null) {
+    return { settings: { latestIsoDate }, transactions: [] }
+  }
+
+  const standardTxs: StandardTx[] = []
+
+  let previousTimestamp = new Date(latestIsoDate).getTime() - QUERY_LOOKBACK
+  if (previousTimestamp < 0) previousTimestamp = 0
+
+  let page = 1
+  let retry = 0
+
+  while (true) {
+    try {
+      const response = await retryFetch(
+        'https://api.swapter.io/personal/exchange/tool-history',
+        {
+          method: 'POST',
+          headers: {
+            'X-Api-Key': apiKey,
+            'Content-Type': 'application/json'
+          },
+          body: JSON.stringify({
+            page,
+            items: LIMIT,
+            timeFrom: previousTimestamp,
+            timeTo: Date.now()
+          })
+        }
+      )
+
+      if (!response.ok) {
+        const text = await response.text()
+        log.error(`Swapter error on page:${page}`)
+        throw new Error(text)
+      }
+
+      const result = asSwapterResult(await response.json())
+      const txs = result.data
+
+      if (txs.length === 0) break
+
+      for (const rawTx of txs) {
+        const standardTx = processSwapterTx(rawTx, pluginParams)
+
+        standardTxs.push(standardTx)
+
+        if (standardTx.isoDate > latestIsoDate) {
+          latestIsoDate = standardTx.isoDate
+        }
+      }
+
+      log(`Swapter page ${page} latestIsoDate ${latestIsoDate}`)
+
+      const loaded = page * LIMIT
+      if (loaded >= result.total) break
+
+      page++
+      retry = 0
+    } catch (e) {
+      log.error(String(e))
+
+      retry++
+      if (retry <= MAX_RETRIES) {
+        log.warn(`Snoozing ${5 * retry}s`)
+        await snooze(5000 * retry)
+      } else {
+        break
+      }
+    }
+  }
+
+  return {
+    settings: { latestIsoDate },
+    transactions: standardTxs
+  }
+}
+
+export const swapter: PartnerPlugin = {
+  queryFunc: querySwapter,
+  pluginName: 'Swapter',
+  pluginId: 'swapter'
+}
+
+export function processSwapterTx(
+  rawTx: unknown,
+  pluginParams: PluginParams
+): StandardTx {
+  const tx: SwapterTx = asSwapterTx(rawTx)
+
+  const { timestamp, isoDate } = smartIsoDateFromTimestamp(tx.time.create)
+
+  return {
+    status: statusMap[tx.info.status],
+    orderId: tx.info.uid,
+    countryCode: null,
+
+    depositTxid: undefined,
+    depositAddress: tx.deposit.address,
+    depositCurrency: tx.deposit.coin.toUpperCase(),
+    depositChainPluginId: undefined,
+    depositEvmChainId: undefined,
+    depositTokenId: undefined,
+    depositAmount: tx.deposit.actual ?? tx.deposit.amount,
+
+    direction: null,
+    exchangeType: 'swap',
+    paymentType: null,
+
+    payoutTxid: undefined,
+    payoutAddress: tx.withdraw.address,
+    payoutCurrency: tx.withdraw.coin.toUpperCase(),
+    payoutChainPluginId: undefined,
+    payoutEvmChainId: undefined,
+    payoutTokenId: undefined,
+    payoutAmount: tx.withdraw.amount,
+
+    timestamp,
+    isoDate,
+
+    usdValue: tx.info.equivalent > 0 ? tx.info.equivalent : -1,
+
+    rawTx
+  }
+}

--- a/src/queryEngine.ts
+++ b/src/queryEngine.ts
@@ -28,6 +28,7 @@ import { rango } from './partners/rango'
 import { safello } from './partners/safello'
 import { sideshift } from './partners/sideshift'
 import { simplex } from './partners/simplex'
+import { swapter } from './partners/swapter'
 import { swapuz } from './partners/swapuz'
 import { switchain } from './partners/switchain'
 import { maya, thorchain } from './partners/thorchain'
@@ -80,6 +81,7 @@ const plugins = [
   safello,
   sideshift,
   simplex,
+  swapter,
   swapuz,
   switchain,
   thorchain,


### PR DESCRIPTION
### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

none

### Description

Adds the Swapter exchange partner integration to the reports server. Recreated under the EdgeApp org from the external contributor PR https://github.com/EdgeApp/edge-reports-server/pull/219 so we own the branch and can ship it.

Changes:

- New `src/partners/swapter.ts`: `querySwapter` pages the `POST /personal/exchange/tool-history` endpoint (200/page) with `X-Api-Key` auth, `retryFetch` + snooze-backoff retry handling, and `latestIsoDate` tracking to skip already-processed orders. `processSwapterTx` cleans each raw record and converts it into a `StandardTx` (deposit/withdraw coin+amount+address, `deposit.actual ?? deposit.amount`, `usdValue` from `info.equivalent` with the `-1` unknown guard).
- Swapter status → Edge `Status` mapping covering all nine documented statuses plus an `other` fallback for unknown values.
- Registers the `swapter` plugin (`pluginId: swapter`) in `src/queryEngine.ts`.

Testing:

- `processSwapterTx` output validated against the canonical `asStandardTx` cleaner on a representative order; all status mappings, the `actual ?? amount` fallback, and the `usdValue` guard verified.
- `querySwapter` run against the live `https://api.swapter.io/personal/exchange/tool-history` API with a throwaway non-prod key: HTTP 200, response accepted by `asSwapterResult`, empty history for the key so it returns `[]` cleanly. Missing-apiKey path short-circuits to `[]` without throwing.
- `tsc` (via `prepare`/`build.*`) and `eslint` on the changed files pass. The `util.test` suite is red both on this branch and on pristine `master` (pre-existing `sevenDayDataMerge` / `createQuarterBuckets` failures, unrelated to this change).

Asana: https://app.asana.com/0/1215088146871429/1216466181647587

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive partner integration following existing plugin patterns; no changes to core auth, storage semantics, or shared reporting logic beyond registering one more plugin.
> 
> **Overview**
> Adds **Swapter** as a new exchange partner so the reports query loop can ingest swap history into `StandardTx` records.
> 
> The new plugin posts to Swapter’s `tool-history` API with `X-Api-Key`, paginates (200 per page), applies a 5-day lookback from `latestIsoDate`, and retries failed requests with backoff. Raw orders are normalized via cleaners and mapped to standard fields (deposit/withdraw amounts and addresses, `exchangeType: 'swap'`, status mapping for all documented Swapter states). `usdValue` uses `info.equivalent` when positive, otherwise `-1`. Missing API key returns no transactions without calling the API.
> 
> `swapter` (`pluginId: 'swapter'`) is registered in the query engine plugin list, and the unreleased CHANGELOG notes the addition.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f0536103608157496832c4e3726bea1efbc4b115. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1216013203052254