### PR TITLE
reports: Fix broken test suite and add CI test job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,18 @@
+name: Test
+on: [pull_request]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the latest code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Setup Node
+        uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
+        with:
+          node-version: 18
+      - name: Install dependencies
+        run: npm install --ignore-scripts
+      - name: Generate client config
+        run: node -r sucrase/register src/bin/configure.ts
+      - name: Run tests
+        run: npm test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- added: CI job that runs the mocha test suite on every pull request
 - changed: Update sideshift plugin with new optional API fields
 - changed: Add signature header support to Exolix
 - changed: Add index for orderId
@@ -10,6 +11,7 @@
 - changed: Use rates V3 for transactions with pluginId/tokenId
 - fixed: Moonpay by adding Revolut payment type
 - fixed: Use v2 rates API
+- fixed: Repair the broken mocha test suite (correct util.test.ts import and stale analytics fixtures) so npm test passes
 
 ## 0.2.0
 

--- a/test/testData.json
+++ b/test/testData.json
@@ -1270,7 +1270,7 @@
       "numAllTxs": 165
     },
     "app": "edge",
-    "pluginId": "coinswitch",
+    "partnerId": "coinswitch",
     "start": 1594023608,
     "end": 1596055300
   },
@@ -1549,7 +1549,7 @@
       "numAllTxs": 5
     },
     "app": "app-dummy",
-    "pluginId": "partner-dummy",
+    "partnerId": "partner-dummy",
     "start": 1300000000,
     "end": 1300070000
   },
@@ -2656,7 +2656,7 @@
       "numAllTxs": 5
     },
     "app": "app-dummy",
-    "pluginId": "partner-dummy",
+    "partnerId": "partner-dummy",
     "start": 1708992000,
     "end": 1709424000
   },
@@ -2815,7 +2815,7 @@
       "numAllTxs": 2
     },
     "app": "app-dummy",
-    "pluginId": "partner-dummy",
+    "partnerId": "partner-dummy",
     "start": 1672444800,
     "end": 1706918400
   }

--- a/test/util.test.ts
+++ b/test/util.test.ts
@@ -5,7 +5,7 @@ import {
   createQuarterBuckets,
   movingAveDataSort,
   sevenDayDataMerge
-} from '../lib/util'
+} from '../src/demo/clientUtil'
 import { fixtures } from './utilFixtures.js'
 
 // add case with 1, 2, 3, 4 month bucket


### PR DESCRIPTION
### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

none

### Description

The mocha suite was broken on `master` and CI never caught it because no CI job ran the tests, so PRs stayed green while `npm test` failed. This blocks `pr-land`'s mandatory local verification (it runs `npm test`) on every edge-reports-server landing.

**Fix the broken suite**

- `test/util.test.ts` imported `createQuarterBuckets`, `movingAveDataSort`, and `sevenDayDataMerge` from `../lib/util`, which does not exist (`lib/` is gitignored build output). The functions live in `src/demo/clientUtil.ts`, so the import resolved to `undefined` and crashed the entire suite at load. Repointed the import at `../src/demo/clientUtil`, matching the repo convention of importing source directly under `sucrase/register` (e.g. `test/analytics.test.ts` imports `../src/apiAnalytics`).
- The analytics fixtures (`outputOne..Four` in `test/testData.json`) still expected the stale key `pluginId`, but `getAnalytics` and the `asAnalyticsResult` cleaner both use `partnerId`. Renamed the fixture keys so they match the type contract and the function output.

**Add a CI test job**

- New `.github/workflows/test.yml` runs the mocha suite on every `pull_request`, so a failing suite now blocks the PR.
- The suite loads `src/demo/clientUtil.ts`, which imports the gitignored `clientConfig.json`. The workflow generates it with defaults via the existing `src/bin/configure.ts` (the same step `scripts/prepare.sh` runs) before running the tests, so the job is self-contained without needing the committed config.

Result: `npm test` passes (31 passing, 1 pending — the pre-existing `describe.skip`ped `createQuarterBuckets` block).

Asana: https://app.asana.com/0/1215088146871429/1216467990623863

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to tests, fixtures, CI workflow, and changelog with no production runtime behavior changes.
> 
> **Overview**
> Restores a green **`npm test`** run and adds **GitHub Actions** coverage so broken suites can’t slip through on green PRs.
> 
> **Test fixes:** `test/util.test.ts` now imports util helpers from **`src/demo/clientUtil`** instead of the non-existent **`lib/util`** build path. Analytics golden data in **`test/testData.json`** renames expected **`pluginId`** fields to **`partnerId`** so fixtures match **`getAnalytics`** output.
> 
> **CI:** New **`.github/workflows/test.yml`** runs on every pull request—checkout, Node 18, `npm install --ignore-scripts`, generate **`clientConfig.json`** via **`src/bin/configure.ts`**, then **`npm test`**.
> 
> **CHANGELOG** documents the CI job and test repair.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 89b314ba1a4e0b656e69dd61e48c2ce377f5785d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->