### PR TITLE
Add NYM Swap (nymswap) reporting plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- added: Add NYM Swap (nymswap) reporting
 - changed: Update sideshift plugin with new optional API fields
 - changed: Add signature header support to Exolix
 - changed: Add index for orderId

--- a/src/demo/partners.ts
+++ b/src/demo/partners.ts
@@ -97,6 +97,10 @@ export default {
     type: 'fiat',
     color: '#7214F5'
   },
+  nymswap: {
+    type: 'swap',
+    color: '#FB6E4E'
+  },
   paybis: {
     type: 'fiat',
     color: '#FFB400'

--- a/src/partners/nym.ts
+++ b/src/partners/nym.ts
@@ -1,0 +1,355 @@
+import {
+  asArray,
+  asMaybe,
+  asNumber,
+  asObject,
+  asOptional,
+  asString,
+  asUnknown,
+  asValue
+} from 'cleaners'
+
+import {
+  PartnerPlugin,
+  PluginParams,
+  PluginResult,
+  StandardTx,
+  Status
+} from '../types'
+import {
+  retryFetch,
+  safeParseFloat,
+  smartIsoDateFromTimestamp,
+  snooze
+} from '../util'
+
+// NYM ("nymswap") reporting plugin.
+//
+// Confirmed against NYM's live "Edge Partner" API (OpenAPI at
+// https://nym-swap-api.nymtech.cc/api/docs/) and a live query under the GUI's
+// swap key. The reporting endpoint is
+//   GET /api/partner/v1/reports/transactions
+// authenticated with the same `x-api-key` header the swap plugin uses
+// (edge-exchange-plugins src/swap/central/nym.ts). Query params are `startDate`
+// /`endDate` (ISO date-time), `limit` (<= 500), and an opaque `cursor`; the
+// response is
+//   { transactions: EdgeTransactionRecord[], nextCursor: string | null }
+// paged by following `nextCursor` until it is null.
+//
+// Amounts arrive as native-unit strings (e.g. ETH in wei). StandardTx wants
+// major units, so each is divided by 10^decimals using NYM's own
+// GET /api/partner/v1/currencies list, keyed by currency code + tokenId.
+//
+// The report timestamp is keyed off `createdDate`, not `completedDate`. A live
+// check across every genuinely-settled swap under the GUI key (status
+// `completed` with BOTH a payin and a payout txid) found `completedDate` null on
+// all 7 of them; the only `completed` order that carried a `completedDate` was
+// an anomalous NYM->NYM order with no payin txid. So `completedDate` is not a
+// reliable settlement-time source even for real swaps, and `createdDate` (always
+// present) is used uniformly.
+const NYM_API_BASE = 'https://nym-swap-api.nymtech.cc'
+const REPORTS_PATH = '/api/partner/v1/reports/transactions'
+const CURRENCIES_PATH = '/api/partner/v1/currencies'
+
+// Re-query a 5-day window behind the saved progress so in-flight orders that
+// settle after the previous run are re-seen (mirrors sibling swap partners).
+const QUERY_LOOKBACK = 1000 * 60 * 60 * 24 * 5 // 5 days
+const PAGE_LIMIT = 500 // API max
+const MAX_RETRIES = 5
+
+// Fallback native-unit decimals for NYM's current asset set, used only when the
+// live /currencies fetch fails. The live list overlays this at runtime, so a
+// newly listed asset is picked up automatically. Key: `CODE|tokenIdLower`.
+const DEFAULT_DECIMALS: { [key: string]: number } = {
+  'BTC|': 8,
+  'ETH|': 18,
+  'NYM|': 6,
+  'USDT|0xdac17f958d2ee523a2206206994597c13d831ec7': 6,
+  'USDC|0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48': 6,
+  'NYM|0x525a8f6f3ba4752868cde25164382bfbae3990e1': 6
+}
+
+interface DecimalsMap {
+  [key: string]: number
+}
+
+const decimalsKey = (
+  currencyCode: string,
+  tokenId: string | undefined
+): string => `${currencyCode.toUpperCase()}|${(tokenId ?? '').toLowerCase()}`
+
+export const asNymPluginParams = asObject({
+  settings: asObject({
+    latestIsoDate: asOptional(asString, '1970-01-01T00:00:00.000Z')
+  }),
+  apiKeys: asObject({
+    // Partner-issued reporting key, human/ops-set in production CouchDB
+    // (reports_apps partnerIds.nymswap.apiKeys). Never fetched or set by code.
+    apiKey: asString
+  })
+})
+
+// NYM's EdgeStatus enum. Unknown values degrade to 'other' instead of throwing.
+const asNymStatus = asMaybe(
+  asValue(
+    'pending',
+    'processing',
+    'infoNeeded',
+    'expired',
+    'refunded',
+    'completed'
+  ),
+  'other'
+)
+type NymStatus = ReturnType<typeof asNymStatus>
+
+const statusMap: { [key in NymStatus]: Status } = {
+  pending: 'pending',
+  processing: 'processing',
+  infoNeeded: 'blocked',
+  expired: 'expired',
+  refunded: 'refunded',
+  completed: 'complete',
+  other: 'other'
+}
+
+// A supported-asset entry from GET /api/partner/v1/currencies. Only the fields
+// used to convert native amounts to major units are consumed.
+const asNymCurrency = asObject({
+  currencyCode: asString,
+  tokenId: asMaybe(asString),
+  decimals: asNumber
+})
+const asNymCurrencies = asArray(asNymCurrency)
+
+// One EdgeTransactionRecord. `orderId`/`status`/`createdDate`, the currency
+// codes, and the native-unit amounts are always present; the nullable/optional
+// fields use asMaybe so a partial or differently-typed record degrades to
+// undefined instead of throwing and aborting the whole query block.
+const asNymTransaction = asObject({
+  orderId: asString,
+  status: asNymStatus,
+  createdDate: asString,
+  completedDate: asMaybe(asString),
+
+  // Source (deposit) side.
+  sourceCurrencyCode: asString,
+  sourceTokenId: asMaybe(asString),
+  sourceAmount: asString,
+  payinAddress: asMaybe(asString),
+  payinTxid: asMaybe(asString),
+
+  // Destination (payout) side.
+  destinationCurrencyCode: asString,
+  destinationTokenId: asMaybe(asString),
+  destinationAmount: asString,
+  payoutAddress: asMaybe(asString),
+  payoutTxid: asMaybe(asString)
+})
+
+// Reporting page envelope: `{ transactions, nextCursor }`.
+const asNymResult = asObject({
+  transactions: asArray(asUnknown),
+  nextCursor: asMaybe(asString)
+})
+
+// Converts a native-unit amount string to a major-unit number using the asset's
+// decimals (live /currencies, then DEFAULT_DECIMALS). Throws for an unknown
+// asset so the caller skips the record rather than reporting a mis-scaled
+// amount that would corrupt the downstream USD valuation.
+const toMajorAmount = (
+  nativeAmount: string,
+  currencyCode: string,
+  tokenId: string | undefined,
+  decimals: DecimalsMap
+): number => {
+  const key = decimalsKey(currencyCode, tokenId)
+  const dec = decimals[key] ?? DEFAULT_DECIMALS[key]
+  if (dec == null) {
+    throw new Error(`Unknown decimals for ${key}`)
+  }
+  const native = safeParseFloat(nativeAmount)
+  if (!Number.isFinite(native)) return 0
+  return native / 10 ** dec
+}
+
+// Fetches NYM's supported-asset list into a decimals lookup. Non-fatal: on any
+// error, processNymTx falls back to DEFAULT_DECIMALS for the known asset set.
+const fetchDecimals = async (
+  headers: { [key: string]: string },
+  log: PluginParams['log']
+): Promise<DecimalsMap> => {
+  const decimals: DecimalsMap = {}
+  try {
+    const response = await retryFetch(`${NYM_API_BASE}${CURRENCIES_PATH}`, {
+      method: 'GET',
+      headers
+    })
+    if (!response.ok) throw new Error(await response.text())
+    const currencies = asNymCurrencies(await response.json())
+    for (const c of currencies) {
+      decimals[decimalsKey(c.currencyCode, c.tokenId)] = c.decimals
+    }
+  } catch (e) {
+    log.warn(
+      `Could not fetch NYM currencies, using fallback decimals: ${String(e)}`
+    )
+  }
+  return decimals
+}
+
+export async function queryNym(
+  pluginParams: PluginParams
+): Promise<PluginResult> {
+  const { log } = pluginParams
+  const { settings, apiKeys } = asNymPluginParams(pluginParams)
+  const { apiKey } = apiKeys
+  let { latestIsoDate } = settings
+
+  // Progress persisted before this run. Only advanced past when the full cursor
+  // walk COMPLETES (nextCursor null); on an error-driven early exit we keep this
+  // value so a partial fetch never skips orders we did not page through. This
+  // does not depend on the API's page ordering.
+  const savedIsoDate = latestIsoDate
+
+  const standardTxs: StandardTx[] = []
+  const headers = {
+    'Content-Type': 'application/json',
+    Accept: 'application/json',
+    'x-api-key': apiKey
+  }
+
+  const decimals = await fetchDecimals(headers, log)
+
+  let lookbackTimestamp = new Date(latestIsoDate).getTime() - QUERY_LOOKBACK
+  if (lookbackTimestamp < 0) lookbackTimestamp = 0
+  const startDate = new Date(lookbackTimestamp).toISOString()
+
+  let cursor: string | undefined
+  let retry = 0
+  let completed = false
+
+  while (true) {
+    let url = `${NYM_API_BASE}${REPORTS_PATH}?startDate=${encodeURIComponent(
+      startDate
+    )}&limit=${PAGE_LIMIT}`
+    if (cursor != null) url += `&cursor=${encodeURIComponent(cursor)}`
+    try {
+      const response = await retryFetch(url, { method: 'GET', headers })
+      if (!response.ok) {
+        const text = await response.text()
+        throw new Error(text)
+      }
+      const { transactions, nextCursor } = asNymResult(await response.json())
+      for (const rawTx of transactions) {
+        // Skip a single unparseable/unpriceable record rather than throwing out
+        // to the page retry below, which would re-append this page's already
+        // -pushed records and produce duplicate orderIds.
+        let standardTx: StandardTx
+        try {
+          standardTx = processNymTx(rawTx, decimals)
+        } catch (e) {
+          log.error(`Skipping unparseable transaction: ${String(e)}`)
+          continue
+        }
+        standardTxs.push(standardTx)
+        if (standardTx.isoDate > latestIsoDate) {
+          latestIsoDate = standardTx.isoDate
+        }
+      }
+      log(
+        `cursor=${cursor ?? 'start'} count=${
+          transactions.length
+        } latestIsoDate ${latestIsoDate}`
+      )
+      retry = 0
+      // A null nextCursor marks the last page: the walk is complete.
+      if (nextCursor == null) {
+        completed = true
+        break
+      }
+      cursor = nextCursor
+    } catch (e) {
+      log.error(String(e))
+      // Retry the SAME cursor a few times to ride out throttling.
+      retry++
+      if (retry <= MAX_RETRIES) {
+        log.warn(`Snoozing ${5 * retry}s`)
+        await snooze(5000 * retry)
+      } else {
+        // Give up this run WITHOUT advancing progress (completed stays false),
+        // so the unfetched remainder is re-queried next run. Already-fetched
+        // records are still returned; the cache engine dedupes them by orderId.
+        break
+      }
+    }
+  }
+
+  const out: PluginResult = {
+    settings: { latestIsoDate: completed ? latestIsoDate : savedIsoDate },
+    transactions: standardTxs
+  }
+  return out
+}
+
+export const nymswap: PartnerPlugin = {
+  // queryFunc takes PluginParams and returns a PluginResult
+  queryFunc: queryNym,
+  pluginName: 'NYM',
+  pluginId: 'nymswap'
+}
+
+export function processNymTx(
+  rawTx: unknown,
+  decimals: DecimalsMap = {}
+): StandardTx {
+  const tx = asNymTransaction(rawTx)
+
+  // completedDate is frequently null even on completed orders, so key the report
+  // timestamp off createdDate (always present).
+  const { isoDate, timestamp } = smartIsoDateFromTimestamp(tx.createdDate)
+
+  const depositAmount = toMajorAmount(
+    tx.sourceAmount,
+    tx.sourceCurrencyCode,
+    tx.sourceTokenId,
+    decimals
+  )
+  const payoutAmount = toMajorAmount(
+    tx.destinationAmount,
+    tx.destinationCurrencyCode,
+    tx.destinationTokenId,
+    decimals
+  )
+
+  // Clean shape (mirrors swapuz): carry currency codes + major-unit amounts and
+  // leave the chain/evm/token plugin fields undefined (NYM's `sourceNetwork`
+  // naming does not map 1:1 to Edge plugin ids).
+  const standardTx: StandardTx = {
+    status: statusMap[tx.status],
+    orderId: tx.orderId,
+    countryCode: null,
+    depositTxid: tx.payinTxid,
+    depositAddress: tx.payinAddress,
+    depositCurrency: tx.sourceCurrencyCode.toUpperCase(),
+    depositChainPluginId: undefined,
+    depositEvmChainId: undefined,
+    depositTokenId: undefined,
+    depositAmount,
+    direction: null,
+    exchangeType: 'swap',
+    paymentType: null,
+    payoutTxid: tx.payoutTxid,
+    payoutAddress: tx.payoutAddress,
+    payoutCurrency: tx.destinationCurrencyCode.toUpperCase(),
+    payoutChainPluginId: undefined,
+    payoutEvmChainId: undefined,
+    payoutTokenId: undefined,
+    payoutAmount,
+    timestamp,
+    isoDate,
+    usdValue: -1,
+    rawTx
+  }
+  return standardTx
+}

--- a/src/queryEngine.ts
+++ b/src/queryEngine.ts
@@ -22,6 +22,7 @@ import { letsexchange } from './partners/letsexchange'
 import { libertyx } from './partners/libertyx'
 import { lifi } from './partners/lifi'
 import { moonpay } from './partners/moonpay'
+import { nymswap } from './partners/nym'
 import { paybis } from './partners/paybis'
 import { paytrie } from './partners/paytrie'
 import { rango } from './partners/rango'
@@ -74,6 +75,7 @@ const plugins = [
   lifi,
   maya,
   moonpay,
+  nymswap,
   paybis,
   paytrie,
   rango,

--- a/test/nym.test.ts
+++ b/test/nym.test.ts
@@ -1,0 +1,138 @@
+import { expect } from 'chai'
+import { describe, it } from 'mocha'
+
+import { processNymTx } from '../src/partners/nym'
+
+// Fixtures mirror real EdgeTransactionRecord payloads captured from NYM's live
+// GET /api/partner/v1/reports/transactions endpoint. Amounts are native-unit
+// strings; processNymTx converts them to major units via the asset decimals
+// (DEFAULT_DECIMALS when no live map is passed).
+describe('processNymTx', function() {
+  it('maps a completed order to a StandardTx with major-unit amounts', function() {
+    const rawTx = {
+      orderId: 'order_e73fd5b1c95f4f58',
+      status: 'completed',
+      createdDate: '2026-07-23T16:39:52.238Z',
+      // Real data leaves completedDate null even when completed.
+      completedDate: null,
+      sourceNetwork: 'ethereum',
+      sourceTokenId: null,
+      sourceCurrencyCode: 'ETH',
+      sourceAmount: '15899800000000000', // 0.0158998 ETH (18 decimals)
+      sourceEvmChainId: 1,
+      destinationNetwork: 'NYM',
+      destinationTokenId: null,
+      destinationCurrencyCode: 'NYM',
+      destinationAmount: '1633042311', // 1633.042311 NYM (6 decimals)
+      destinationEvmChainId: null,
+      payinAddress: '0x84F2089CBa3c9680F301bEd56C82e108a6Ab416a',
+      payoutAddress: 'n1fj7fapafrrjxgf8p8qpk0sles7nt8230clvamt',
+      payinTxid:
+        '0xb78ecf0e0a9e44afd030d2f74cbc9f8e3a10fef09559794363b328fac90702df',
+      payoutTxid:
+        'DAB0D9F9531464D687C3E5993B1A5D7645622CAF055CEB96BDFDA1283CF29151'
+    }
+
+    const standardTx = processNymTx(rawTx)
+
+    expect(standardTx.status).to.equal('complete')
+    expect(standardTx.orderId).to.equal('order_e73fd5b1c95f4f58')
+    expect(standardTx.exchangeType).to.equal('swap')
+    expect(standardTx.depositCurrency).to.equal('ETH')
+    expect(standardTx.depositAmount).to.equal(0.0158998)
+    expect(standardTx.depositAddress).to.equal(
+      '0x84F2089CBa3c9680F301bEd56C82e108a6Ab416a'
+    )
+    expect(standardTx.depositTxid).to.equal(rawTx.payinTxid)
+    expect(standardTx.payoutCurrency).to.equal('NYM')
+    expect(standardTx.payoutAmount).to.equal(1633.042311)
+    expect(standardTx.payoutAddress).to.equal(
+      'n1fj7fapafrrjxgf8p8qpk0sles7nt8230clvamt'
+    )
+    expect(standardTx.payoutTxid).to.equal(rawTx.payoutTxid)
+    // Timestamp keys off createdDate (completedDate is null here).
+    expect(standardTx.isoDate).to.equal('2026-07-23T16:39:52.238Z')
+    expect(standardTx.usdValue).to.equal(-1)
+    expect(standardTx.rawTx).to.deep.equal(rawTx)
+  })
+
+  it('converts a token amount using a passed-in live decimals map', function() {
+    const standardTx = processNymTx(
+      {
+        orderId: 'order_ffdd5efef0d54a85',
+        status: 'expired',
+        createdDate: '2026-07-24T04:08:20.021Z',
+        completedDate: null,
+        sourceCurrencyCode: 'USDT',
+        sourceTokenId: '0xdAC17F958D2ee523a2206206994597C13D831ec7',
+        sourceAmount: '32468489', // 32.468489 USDT (6 decimals)
+        payinAddress: '0x84F2089CBa3c9680F301bEd56C82e108a6Ab416a',
+        payinTxid: null,
+        destinationCurrencyCode: 'NYM',
+        destinationTokenId: null,
+        destinationAmount: '1901660695', // 1901.660695 NYM (6 decimals)
+        payoutAddress: 'n1uyqr62rpsn5wjxux74h8lrdypt6pnxgqltds2g',
+        payoutTxid: null
+      },
+      {
+        // Live /currencies overlay keyed CODE|tokenIdLower.
+        'USDT|0xdac17f958d2ee523a2206206994597c13d831ec7': 6,
+        'NYM|': 6
+      }
+    )
+
+    expect(standardTx.status).to.equal('expired')
+    expect(standardTx.depositCurrency).to.equal('USDT')
+    expect(standardTx.depositAmount).to.equal(32.468489)
+    expect(standardTx.payoutAmount).to.equal(1901.660695)
+    // Nullable txids degrade to undefined, not throw.
+    expect(standardTx.depositTxid).to.equal(undefined)
+    expect(standardTx.payoutTxid).to.equal(undefined)
+  })
+
+  it('degrades an unknown status to other', function() {
+    const standardTx = processNymTx({
+      orderId: 'order_unknownstatus',
+      status: 'some-new-status',
+      createdDate: '2026-07-22T00:00:00.000Z',
+      sourceCurrencyCode: 'BTC',
+      sourceAmount: '10000', // 0.0001 BTC (8 decimals)
+      destinationCurrencyCode: 'NYM',
+      destinationAmount: '5000000' // 5 NYM (6 decimals)
+    })
+
+    expect(standardTx.status).to.equal('other')
+    expect(standardTx.depositAmount).to.equal(0.0001)
+    expect(standardTx.payoutAmount).to.equal(5)
+  })
+
+  it('throws for an asset with no known decimals so the caller can skip it', function() {
+    expect(() =>
+      processNymTx({
+        orderId: 'order_unknownasset',
+        status: 'completed',
+        createdDate: '2026-07-22T00:00:00.000Z',
+        sourceCurrencyCode: 'FOO',
+        sourceAmount: '100',
+        destinationCurrencyCode: 'NYM',
+        destinationAmount: '5000000'
+      })
+    ).to.throw(/Unknown decimals for FOO/)
+  })
+
+  it('clamps a non-numeric native amount to 0', function() {
+    const standardTx = processNymTx({
+      orderId: 'order_badamount',
+      status: 'completed',
+      createdDate: '2026-07-22T00:00:00.000Z',
+      sourceCurrencyCode: 'BTC',
+      sourceAmount: 'not-a-number',
+      destinationCurrencyCode: 'NYM',
+      destinationAmount: '5000000'
+    })
+
+    // NaN must never reach StandardTx (it serializes to null in CouchDB).
+    expect(standardTx.depositAmount).to.equal(0)
+    expect(standardTx.payoutAmount).to.equal(5)
+  })
+})


### PR DESCRIPTION
### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

none

### Description

Add a new reports-server partner plugin `nymswap` so NYM swaps surface in the reports
pipeline. Asana: https://app.asana.com/0/1215088146871429/1216728226940270

The reporting contract is confirmed against NYM's live "Edge Partner" API (OpenAPI at
https://nym-swap-api.nymtech.cc/api/docs/) and a live query run under the GUI's existing
NYM swap key (`NYM_SWAP_INIT.apiKey`), which had real order history to read.

What it does:
- `src/partners/nym.ts` - `queryNym` walks `GET /api/partner/v1/reports/transactions`
  (auth `x-api-key`, params `startDate`/`endDate`/`limit<=500`/`cursor`, envelope
  `{ transactions, nextCursor }`), following `nextCursor` until null with a 5-day lookback,
  retry/snooze on throttling, and a conservative progress save (advance `latestIsoDate` only
  after the full cursor walk completes). `processNymTx` maps each `EdgeTransactionRecord`
  into `StandardTx`.
- Native-unit string amounts are converted to major units via NYM's own
  `GET /api/partner/v1/currencies` decimals (keyed by currency code + tokenId), with a
  built-in fallback map for the current asset set if that fetch fails.
- Report timestamp keys off `createdDate` because NYM leaves `completedDate` null on most
  completed orders (observed 7 of 8 in the live sample).
- Status enum mapped `pending/processing/infoNeeded/expired/refunded/completed` to Edge
  StandardTx statuses.
- Registered `nymswap` in `src/queryEngine.ts` and `src/demo/partners.ts`. The `pluginId`
  is `nymswap`, matching the NYM swap plugin in edge-exchange-plugins.
- `test/nym.test.ts` - unit tests for `processNymTx` using real captured `EdgeTransactionRecord`
  payloads (amount decimal conversion, unknown-status degradation, null-txid tolerance,
  unknown-asset skip, non-numeric amount clamp).

Credentials are human/ops only for production (partner dashboard + production CouchDB
`reports_apps partnerIds.nymswap.apiKeys`); no production credential is fetched or set by
this code. The live verification used the GUI's existing swap key at the operator's request.

Open questions raised with the NYM team (see the Asana task):
- `completedDate` is null on completed orders - should reporting rely on `createdDate` for
  the settlement time, or will `completedDate` be populated?
- `sourceNetwork`/`destinationNetwork` casing is inconsistent (`ethereum` vs `BTC`/`NYM`) and
  does not map 1:1 to Edge plugin ids; chain plugin fields are left undefined for now.
- Confirm the production reporting key is the same key/scheme as the swap key, or a distinct
  reporting credential.

Testing:
- Live query against `GET /api/partner/v1/reports/transactions` under the GUI key returned
  21 real records (8 completed, 13 expired); the response matched the OpenAPI `TransactionReport`
  schema exactly and drove the cleaner design.
- Repo typecheck (`tsc` / `build.types`) clean of the new code; eslint clean on changed files.
- `test/nym.test.ts` passes (5/5).
- Note: the repo's existing mocha suite has 31 pre-existing failures (apiAnalytics + util
  date-math) unrelated to this change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New external API integration affects reported swap amounts and timestamps (createdDate vs settlement); mis-scaled decimals are guarded by skipping unknown assets, but ops must configure the API key in CouchDB.
> 
> **Overview**
> Adds **NYM Swap (`nymswap`)** to the reports pipeline so Edge can ingest partner swap history from NYM’s Partner API.
> 
> A new plugin in `src/partners/nym.ts` pages `GET /api/partner/v1/reports/transactions` with `x-api-key`, a **5-day lookback**, cursor pagination, and retries; **`latestIsoDate` advances only after the full cursor walk finishes** so partial runs do not skip data. Native amount strings are scaled to major units using live **`/currencies`** decimals (with a static fallback), records map to **`StandardTx`** (status mapping, **`createdDate`** for timestamps because **`completedDate`** is often null), and bad rows are skipped instead of failing the whole page.
> 
> **`nymswap`** is wired into **`queryEngine`** and the demo partner list; **CHANGELOG** and **`test/nym.test.ts`** cover `processNymTx` conversion and edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 834e37a42a9580586a8bb19c74e70dc227df93de. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->