### PR TITLE
Fix test suite, add Swapter/NYM/Revolut plugins, and add isolated v2 dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - added: Add Revolut fiat payment provider
 - added: Add Swapter reporting
 - added: Add NYM Swap (nymswap) reporting
+- added: Isolated v2 reports dashboard at /v2/ (real /v1 API data, apiKey auth with redirect on a bad key)
 - changed: Update sideshift plugin with new optional API fields
 - changed: Query both old and new Sideshift affiliate accounts and merge completed orders to preserve full shift history across an affiliate-account rotation
 - changed: Add signature header support to Exolix

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - added: Add Swapter reporting
 - added: Add NYM Swap (nymswap) reporting
 - added: Isolated v2 reports dashboard at /v2/ (real /v1 API data, apiKey auth with redirect on a bad key)
+- added: Partner-reported revenue (revenueUsd/revenueSource) on StandardTx, summed through the analytics cache; Revolut reports it, and the v2 dashboard uses reported figures where present with volume x revShareRate as the estimate elsewhere
 - changed: Update sideshift plugin with new optional API fields
 - changed: Query both old and new Sideshift affiliate accounts and merge completed orders to preserve full shift history across an affiliate-account rotation
 - changed: Add signature header support to Exolix

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "build.lib": "sucrase -q -t typescript,imports,jsx -d ./lib ./src",
     "build.types": "tsc",
-    "build.dist": "parcel build",
+    "build.dist": "parcel build && parcel build src/demoV2/index.html --dist-dir dist/v2 --public-url ./",
     "clean": "rimraf lib dist .parcel-cache",
     "configure": "configure",
     "fix": "npm run lint -- --fix",
@@ -27,6 +27,7 @@
     "stats": "node -r sucrase/register src/bin/partitionStats.ts",
     "test": "mocha -r sucrase/register 'test/**/*.test.ts'",
     "demo": "parcel serve src/demo/index.html",
+    "demo.v2": "parcel serve src/demoV2/index.html --dist-dir dist/v2 --public-url ./ -p 1235",
     "lint": "eslint --ext .js,.jsx,.ts,.tsx ."
   },
   "lint-staged": {

--- a/src/apiAnalytics.ts
+++ b/src/apiAnalytics.ts
@@ -13,12 +13,14 @@ interface DbTx {
   payoutCurrency: string
   timestamp: number
   usdValue: number
+  revenueUsd?: number
 }
 
 interface Bucket {
   start: number
   usdValue: number
   numTxs: number
+  revenueUsd: number
   isoDate: string
   currencyCodes: { [currencyCode: string]: number }
   currencyPairs: { [currencyPair: string]: number }
@@ -49,6 +51,7 @@ export const getAnalytics = (
         isoDate: monthStart.toISOString(),
         usdValue: 0,
         numTxs: 0,
+        revenueUsd: 0,
         currencyCodes: {},
         currencyPairs: {}
       })
@@ -66,6 +69,7 @@ export const getAnalytics = (
         isoDate: dayStart.toISOString(),
         usdValue: 0,
         numTxs: 0,
+        revenueUsd: 0,
         currencyCodes: {},
         currencyPairs: {}
       })
@@ -83,6 +87,7 @@ export const getAnalytics = (
         isoDate: hourStart.toISOString(),
         usdValue: 0,
         numTxs: 0,
+        revenueUsd: 0,
         currencyCodes: {},
         currencyPairs: {}
       })
@@ -160,6 +165,8 @@ const bucketAdder = (bucket: Bucket, tx: DbTx): void => {
   bucket.numTxs++
   // usdValue
   bucket.usdValue += tx.usdValue != null ? tx.usdValue : 0
+  // reported revenue (partners that do not report one contribute 0)
+  bucket.revenueUsd += tx.revenueUsd != null ? tx.revenueUsd : 0
   // currencyCode
   if (bucket.currencyCodes[tx.depositCurrency] == null) {
     bucket.currencyCodes[tx.depositCurrency] = 0

--- a/src/cacheEngine.ts
+++ b/src/cacheEngine.ts
@@ -101,7 +101,8 @@ export async function cacheEngine(): Promise<void> {
               'depositCurrency',
               'payoutCurrency',
               'timestamp',
-              'usdValue'
+              'usdValue',
+              'revenueUsd'
             ],
             use_index: 'timestamp-p',
             sort: ['timestamp'],
@@ -145,6 +146,7 @@ export async function cacheEngine(): Promise<void> {
                 timestamp: bucket.start,
                 usdValue: bucket.usdValue,
                 numTxs: bucket.numTxs,
+                revenueUsd: bucket.revenueUsd,
                 currencyCodes: bucket.currencyCodes,
                 currencyPairs: bucket.currencyPairs
               }

--- a/src/dbutils.ts
+++ b/src/dbutils.ts
@@ -1,4 +1,4 @@
-import { asArray, asNumber, asObject, asString } from 'cleaners'
+import { asArray, asNumber, asObject, asOptional, asString } from 'cleaners'
 import nano from 'nano'
 
 import { config } from './config'
@@ -15,7 +15,8 @@ export const asDbReq = asObject({
       depositCurrency: asString,
       payoutCurrency: asString,
       timestamp: asNumber,
-      usdValue: asNumber
+      usdValue: asNumber,
+      revenueUsd: asOptional(asNumber)
     })
   )
 })
@@ -106,6 +107,7 @@ export const cacheAnalytic = async (
             start: cacheObj.timestamp,
             usdValue: cacheObj.usdValue,
             numTxs: cacheObj.numTxs,
+            revenueUsd: cacheObj.revenueUsd,
             isoDate: new Date(cacheObj.timestamp).toISOString(),
             currencyCodes: cacheObj.currencyCodes,
             currencyPairs: cacheObj.currencyPairs

--- a/src/demo/clientUtil.ts
+++ b/src/demo/clientUtil.ts
@@ -144,6 +144,7 @@ export const createQuarterBuckets = (analytics: AnalyticsResult): Bucket[] => {
       start: realTimestamp / 1000,
       usdValue: 0,
       numTxs: 0,
+      revenueUsd: undefined,
       isoDate: new Date(realTimestamp).toISOString(),
       currencyCodes: {},
       currencyPairs: {}

--- a/src/demoV2/README.md
+++ b/src/demoV2/README.md
@@ -1,0 +1,81 @@
+# Edge Reports v2 dashboard
+
+An isolated redesign of the reports dashboard, served at `/v2/`. It is fully
+separate from the v1 demo (`src/demo`): its own entry point, its own parcel
+bundle (`dist/v2/`), and its own URL. v1 routes, components and build output are
+untouched. Where behavior overlaps, code is duplicated into v2 rather than
+refactoring anything v1 depends on.
+
+## What it is
+
+The full rendering and interaction engine is ported from the design prototype:
+one summary card, a Providers section and a Currency pairs section, each with a
+trend chart (stacked bars or lines), a share card (donut + ranked bars, hover
+linked), and a detail table (the pair table paginated). Global filters (range,
+type, providers, pairs) scope every card. Top-8-plus-Other color rules keep the
+chart, share card and table in agreement.
+
+The only thing that changed from the prototype is the data source: the baked-in
+sample generator is replaced by the real `/v1` reporting API.
+
+## Data flow
+
+- `GET /v1/getAppId?apiKey=` — validates the key. Returns plain text on a bad
+  key (400); v2 checks the response before parsing and redirects to the
+  key-entry screen instead of hanging (the v1 spinner-forever bug).
+- `GET /v2/config?apiKey=` — per-provider rev-share rates and fiat/swap
+  classification. Isolated v2 route; no v1 route touched.
+- `GET /v1/getPluginIds?apiKey=` — the app's registered providers.
+- `POST /v1/analytics` — one call for all providers, `timePeriod: "day"`, last
+  24 months. v2 rebuckets to month client-side for the longer presets.
+
+Auth reuses v1's simple apiKey model: the key lives in the `apiKey` cookie (a
+`?apiKey=` query param also seeds it). No new auth system.
+
+### Est. revenue
+
+The reporting API has no revenue field. v2 derives estimated revenue client-side
+as `volume * revShareRate`, where the rate map is keyed by pluginId. Providers
+with no rate contribute 0.
+
+The rates live in the `reports_settings` db as the `revShareRates` doc, the same
+place `currencyCodeMappings` already lives:
+
+```json
+{ "_id": "revShareRates", "rates": { "<pluginId>": 0.005 } }
+```
+
+They are deliberately not in source or `config.json`: they are commercial terms
+and this repo is public. A missing doc means no rates, and the dashboard shows 0
+estimated revenue rather than a number that should not be public.
+
+## Local testing
+
+Run against a local CouchDB (never point at production).
+
+```bash
+# 1) Build v1 + v2 bundles (v2 lands in dist/v2/).
+npm run build.dist
+
+# 2) Serve the API + built dashboards.
+npm run start.api        # http://localhost:8008
+
+# 3) Open the dashboard and enter an API key registered in reports_apps.
+open http://localhost:8008/v2/
+```
+
+The dashboard needs an app registered in the `reports_apps` database: a document
+whose `_id` is the API key, with an `appId` and a `partnerIds` map. That is what
+`getAppId`, `getPluginIds` and `validateApiKey` read. Populate transaction data
+with the normal engines (`npm run start` to query partners, `npm run start.cache`
+to build the hour/day/month cache buckets that `/v1/analytics` serves).
+
+For live-reload development of the v2 UI only: `npm run demo.v2` (Parcel dev
+server on :1235). Point it at a running API via same-origin or a proxy; the
+`build.dist` + `start.api` path above is the end-to-end test.
+
+Partner credentials belong in the `reports_apps` document, not in `config.json`
+and not in any tracked file. Writing real keys into production is a human ops
+step. A null apiKey makes a partner plugin skip silently and return no rows, so
+"no data" and "never wired" look the same; check the key is populated before
+concluding a plugin is broken.

--- a/src/demoV2/README.md
+++ b/src/demoV2/README.md
@@ -34,20 +34,27 @@ Auth reuses v1's simple apiKey model: the key lives in the `apiKey` cookie (a
 
 ### Est. revenue
 
-The reporting API has no revenue field. v2 derives estimated revenue client-side
-as `volume * revShareRate`, where the rate map is keyed by pluginId. Providers
-with no rate contribute 0.
+Where the partner's API reports Edge's actual fee per order (e.g. Revolut's
+`partner_fee`, pre-converted to USD), the plugin stores it on the transaction as
+`revenueUsd` with `revenueSource: 'reported'`, the cache engine sums it into the
+analytics buckets, and the dashboard uses it directly, marked with a check in
+the provider table. That figure is a fact about the order and never recomputed.
 
-The rates live in the `reports_settings` db as the `revShareRates` doc, the same
-place `currencyCodeMappings` already lives:
+For partners that report no fee, revenue is estimated at read time as
+`volume * revShareRate`. The rate lives on the app doc in `reports_apps`, as an
+optional `revShareRate` beside that partner's `apiKeys`:
 
 ```json
-{ "_id": "revShareRates", "rates": { "<pluginId>": 0.005 } }
+"partnerIds": {
+  "moonpay": { "apiKeys": { "apiKey": "..." }, "revShareRate": 0.008 }
+}
 ```
 
-They are deliberately not in source or `config.json`: they are commercial terms
-and this repo is public. A missing doc means no rates, and the dashboard shows 0
-estimated revenue rather than a number that should not be public.
+Per app and per partner, because the rate is a property of the deal. Estimating
+at read time rather than at ingest means correcting a rate fixes history
+immediately, while reported figures stay immutable. The rates are deliberately
+not in source or `config.json`: they are commercial terms and this repo is
+public. A partner with neither reported fees nor a rate contributes 0.
 
 ## Local testing
 

--- a/src/demoV2/index.html
+++ b/src/demoV2/index.html
@@ -412,7 +412,7 @@
     <h3>What changed vs the current site, and why</h3>
     <ul>
       <li><b>Two entity groups, one top-level filter row, every filter scopes every card.</b> The page is grouped into Providers and Currency pairs, and all four filters (range, type, providers, pairs) apply to the whole page including the summary. One data caveat: the API records volume per pair but not transactions per pair, so under a pair filter each provider's txs (and avg tx) are estimated by scaling its tx count by that pair share of its volume.</li>
-      <li><b>Revenue is a first-class metric.</b> The current site only shows gross volume. This design applies a per-provider rev-share rate to volume (rates editable in config) and shows Est. revenue in the summary, the provider trend, and the table. Data requirement: the analytics response has no revenue field today; either compute client-side from a rates map or add it to the cache/API.</li>
+      <li><b>Revenue is a first-class metric.</b> The current site only shows gross volume. Where the partner's API reports Edge's actual fee (e.g. Revolut), buckets carry the summed reported revenue and the dashboard uses it directly, marked with a check. Everywhere else revenue is estimated as volume times the app doc's per-partner rev-share rate.</li>
       <li><b>Trend + share pairing.</b> Each group gets a time-series card (stacked bars or lines per entity), a share card (donut for at-a-glance proportion, ranked horizontal bars for exact comparison), and a detail table (the pair table is paginated with a rows-per-page control). No dual-axis charts anywhere; the metric toggle swaps the whole view instead.</li>
       <li><b>Hover to focus, filter only up top.</b> Legend pills highlight their series on hover (everything else dims) instead of mutating the global filter; the donut and ranked bars in each share card are hover-linked (a segment pops out and its row highlights, and vice versa). Share cards show exactly the same top 8 + Other split as their trend chart, and every trend and share card has its own local "include other" checkbox that hides the folded tail from that card only (share totals and percentages recompute over what is shown).</li>
       <li><b>Number formatting.</b> Compact in tiles, axes and bars ($40.7M), full precision in tooltips and the table. Clean rounded axis ticks.</li>
@@ -422,7 +422,7 @@
     </ul>
     <h4>Data source</h4>
     <ul>
-      <li>Live data from the <b>/v1</b> reporting API: <b>getAppId</b> (apiKey auth), <b>getPluginIds</b> (provider list) and one <b>analytics</b> POST (daily buckets, last 24 months) for all providers at once. Est. revenue is derived client-side from the per-provider rev-share rates in server config (<b>/v2/config</b>); the analytics response has no revenue field.</li>
+      <li>Live data from the <b>/v1</b> reporting API: <b>getAppId</b> (apiKey auth), <b>getPluginIds</b> (provider list) and one <b>analytics</b> POST (daily buckets, last 24 months) for all providers at once. Revenue uses the bucket's partner-reported <b>revenueUsd</b> when the provider reports one, and otherwise is estimated client-side from the per-partner rev-share rates on the app doc (served by <b>/v2/config</b>).</li>
       <li>A bad or missing API key now redirects to the key-entry screen instead of hanging: getAppId returns plain text on 400, so the response is checked before parsing and fetch errors are surfaced.</li>
       <li>Pair transactions are not recorded by the API (only pair volume), so under a pair filter each provider's txs and avg tx are estimated by scaling its tx count by that pair's share of its volume.</li>
     </ul>
@@ -527,7 +527,7 @@ function displayName(pluginId) {
 function buildProviderDaily(dayBuckets) {
   const arr = new Array(DAYS);
   for (let idx = 0; idx < DAYS; idx++) {
-    arr[idx] = { t: new Date(TODAY.getTime() - (DAYS - 1 - idx) * DAY), usd: 0, txs: 0, pairs: {} };
+    arr[idx] = { t: new Date(TODAY.getTime() - (DAYS - 1 - idx) * DAY), usd: 0, txs: 0, rev: 0, pairs: {} };
   }
   for (const b of dayBuckets) {
     const bucketDayIndex = utcDayIndex(b.start * 1000); // bucket.start is seconds
@@ -536,6 +536,7 @@ function buildProviderDaily(dayBuckets) {
     const slot = arr[idx];
     slot.usd += b.usdValue || 0;
     slot.txs += b.numTxs || 0;
+    slot.rev += b.revenueUsd || 0; // reported by the partner, summed at ingest
     const pairs = b.currencyPairs || {};
     for (const k in pairs) slot.pairs[k] = (slot.pairs[k] || 0) + pairs[k];
   }
@@ -570,6 +571,11 @@ async function loadData(apiKey) {
   });
   // A provider is "active" if it moved any volume in the loaded window.
   PROVIDERS.forEach(p => { p.active = daily[p.i].some(b => b.usd > 0); });
+  // "reported": the partner's API reports Edge's actual fee per order, so
+  // revenue for this provider is fact, not volume * rate. Detected from the
+  // data rather than configured, so a partner that starts reporting upgrades
+  // itself on the next cache rebuild.
+  PROVIDERS.forEach(p => { p.reported = daily[p.i].some(b => b.rev > 0); });
 
   initDerived();
 }
@@ -655,19 +661,24 @@ const typeMatch = p => state.type === 'all' || p.type === state.type;
 function bucketSlice(b) {
   let pv = 0, tot = 0;
   for (const k in b.pairs) { tot += b.pairs[k]; if (state.enabledPairs.has(k)) pv += b.pairs[k]; }
-  return { vol: pv, txs: tot > 0 ? b.txs * pv / tot : 0 };
+  // Reported revenue is per bucket, not per pair, so pair filtering attributes
+  // it proportionally to the filtered share of volume (same rule as txs).
+  return { vol: pv, txs: tot > 0 ? b.txs * pv / tot : 0, rev: tot > 0 ? b.rev * pv / tot : 0 };
 }
+// Revenue for one provider slice: the partner-reported figure when this
+// provider reports one, else the estimate volume * revShareRate.
+function revOf(p, s) { return p.reported ? s.rev : s.vol * p.rr; }
 function providerRows(daysBack) { // per-provider aggregates over the window (type- and pair-filtered)
   const { from, to } = daysBack;
   return PROVIDERS.filter(p => p.active && typeMatch(p)).map(p => {
-    let usd = 0, txs = 0;
+    let usd = 0, txs = 0, rev = 0;
     const arr = daily[p.i];
     for (let d = DAYS - 1 - from; d <= DAYS - 1 - to; d++) {
       const b = arr[d]; if (!b) continue;
       const s = bucketSlice(b);
-      usd += s.vol; txs += s.txs;
+      usd += s.vol; txs += s.txs; rev += revOf(p, s);
     }
-    return { p, usd, txs, rev: usd * p.rr };
+    return { p, usd, txs, rev };
   });
 }
 function provBuckets(daysBack) { // time buckets per enabled provider
@@ -687,7 +698,7 @@ function provBuckets(daysBack) { // time buckets per enabled provider
       const b = daily[p.i][DAYS - 1 - d]; if (!b) continue;
       const s = bucketSlice(b);
       const v = slot.vals[p.name] || (slot.vals[p.name] = { usd: 0, txs: 0, rev: 0 });
-      v.usd += s.vol; v.txs += s.txs; v.rev += s.vol * p.rr;
+      v.usd += s.vol; v.txs += s.txs; v.rev += revOf(p, s);
     }
   }
   return { out, gran };
@@ -825,7 +836,7 @@ function renderSummary() {
     for (const p of PROVIDERS.filter(p => p.active && typeMatch(p) && state.enabled.has(p.name))) {
       const b = daily[p.i][DAYS - 1 - d]; if (!b) continue;
       const s = bucketSlice(b);
-      v += s.vol; t += s.txs; r += s.vol * p.rr;
+      v += s.vol; t += s.txs; r += revOf(p, s);
     }
     days.push({ v, t, r });
   }
@@ -1194,7 +1205,9 @@ function renderTable() {
     sb.appendChild(fi);
     const pt = document.createElement('span'); pt.textContent = (r.share * 100).toFixed(1) + '%';
     sc.append(sb, pt); td.appendChild(sc); tr.appendChild(td);
-    td = document.createElement('td'); td.textContent = fmtMoney(r.rev); tr.appendChild(td);
+    td = document.createElement('td'); td.textContent = fmtMoney(r.rev);
+    if (r.p.reported) { td.textContent += ' \u2713'; td.title = 'Reported by the partner (actual fees), not estimated'; }
+    tr.appendChild(td);
     td = document.createElement('td'); td.textContent = Math.round(r.txs).toLocaleString('en-US'); tr.appendChild(td);
     td = document.createElement('td'); td.textContent = fmtMoney(r.avg); tr.appendChild(td);
     td = document.createElement('td');
@@ -1249,10 +1262,14 @@ function pairDetailRows(daysBack) {
   for (const p of PROVIDERS.filter(p => p.active && typeMatch(p) && state.enabled.has(p.name))) {
     for (let d = from; d >= to; d--) {
       const b = daily[p.i][DAYS - 1 - d]; if (!b) continue;
+      // Reported revenue is per bucket, so attribute it to pairs by volume
+      // share (same proportional rule as bucketSlice).
+      let tot = 0; for (const k in b.pairs) tot += b.pairs[k];
       for (const k in b.pairs) {
         if (!state.enabledPairs.has(k)) continue;
         const a = agg[k] || (agg[k] = { vol: 0, rev: 0, provs: new Set() });
-        a.vol += b.pairs[k]; a.rev += b.pairs[k] * p.rr;
+        a.vol += b.pairs[k];
+        a.rev += p.reported ? (tot > 0 ? b.rev * b.pairs[k] / tot : 0) : b.pairs[k] * p.rr;
         if (b.pairs[k] > 0) a.provs.add(p.name);
       }
     }

--- a/src/demoV2/index.html
+++ b/src/demoV2/index.html
@@ -1,0 +1,1544 @@
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Edge Reports v2</title>
+<style>
+  :root {
+    color-scheme: light;
+    --surface-1: #fcfcfb; --page: #f9f9f7;
+    --ink-1: #0b0b0b; --ink-2: #52514e; --ink-3: #898781;
+    --grid: #e1e0d9; --axis: #c3c2b7; --border: rgba(11,11,11,0.10);
+    --good: #006300; --bad: #d03b3b;
+    --accent: #2a78d6;
+    --s1:#2a78d6; --s2:#eb6834; --s3:#1baf7a; --s4:#eda100;
+    --s5:#e87ba4; --s6:#008300; --s7:#4a3aa7; --s8:#e34948;
+    --other:#898781;
+    --wash: rgba(11,11,11,0.04);
+  }
+  @media (prefers-color-scheme: dark) {
+    :root:where(:not([data-theme="light"])) {
+      color-scheme: dark;
+      --surface-1: #1a1a19; --page: #0d0d0d;
+      --ink-1: #ffffff; --ink-2: #c3c2b7; --ink-3: #898781;
+      --grid: #2c2c2a; --axis: #383835; --border: rgba(255,255,255,0.10);
+      --good: #0ca30c; --bad: #e66767;
+      --accent: #3987e5;
+      --s1:#3987e5; --s2:#d95926; --s3:#199e70; --s4:#c98500;
+      --s5:#d55181; --s6:#008300; --s7:#9085e9; --s8:#e66767;
+      --wash: rgba(255,255,255,0.06);
+    }
+  }
+  :root[data-theme="dark"] {
+    color-scheme: dark;
+    --surface-1: #1a1a19; --page: #0d0d0d;
+    --ink-1: #ffffff; --ink-2: #c3c2b7; --ink-3: #898781;
+    --grid: #2c2c2a; --axis: #383835; --border: rgba(255,255,255,0.10);
+    --good: #0ca30c; --bad: #e66767;
+    --accent: #3987e5;
+    --s1:#3987e5; --s2:#d95926; --s3:#199e70; --s4:#c98500;
+    --s5:#d55181; --s6:#008300; --s7:#9085e9; --s8:#e66767;
+    --wash: rgba(255,255,255,0.06);
+  }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0; background: var(--page); color: var(--ink-1);
+    font: 14px/1.45 system-ui, -apple-system, "Segoe UI", sans-serif;
+  }
+  .wrap { max-width: 1180px; margin: 0 auto; padding: 20px 24px 64px; }
+  header.top { display: flex; align-items: center; gap: 12px; margin-bottom: 16px; }
+  .logo { width: 26px; height: 26px; border-radius: 7px; background: linear-gradient(135deg, #66eda8, #0dad4d); }
+  header.top h1 { font-size: 17px; font-weight: 650; margin: 0; }
+  header.top .sub { color: var(--ink-3); font-size: 12.5px; margin-top: 1px; }
+  .spacer { flex: 1; }
+
+  .btn {
+    background: var(--surface-1); border: 1px solid var(--border); color: var(--ink-1);
+    border-radius: 8px; padding: 6px 11px; font: inherit; font-size: 13px; cursor: pointer;
+  }
+  .btn:hover { background: var(--wash); }
+
+  /* ---------- filter row ---------- */
+  .filters { display: flex; flex-wrap: wrap; gap: 8px; align-items: center; margin-bottom: 14px; position: relative; z-index: 30; }
+  .seg { display: inline-flex; background: var(--surface-1); border: 1px solid var(--border); border-radius: 8px; padding: 2px; }
+  .seg button {
+    border: 0; background: transparent; color: var(--ink-2); font: inherit; font-size: 13px;
+    padding: 5px 11px; border-radius: 6px; cursor: pointer; white-space: nowrap;
+  }
+  .seg button:hover { color: var(--ink-1); }
+  .seg button.on { background: var(--wash); color: var(--ink-1); font-weight: 600; }
+  .dd { position: relative; }
+  .dd-panel {
+    position: absolute; top: calc(100% + 6px); left: 0; min-width: 218px;
+    background: var(--surface-1); border: 1px solid var(--border); border-radius: 10px;
+    box-shadow: 0 8px 28px rgba(0,0,0,.12); padding: 6px; display: none; z-index: 40;
+  }
+  .dd.open .dd-panel { display: block; }
+  .dd-row {
+    display: flex; align-items: center; gap: 8px; width: 100%; text-align: left;
+    border: 0; background: transparent; color: var(--ink-1); font: inherit; font-size: 13px;
+    padding: 7px 9px; border-radius: 7px; cursor: pointer;
+  }
+  .dd-row:hover { background: var(--wash); }
+  .dd-row .check { width: 16px; font-weight: 700; color: var(--accent); }
+  .dd-foot { border-top: 1px solid var(--border); margin-top: 6px; padding: 9px 9px 4px; }
+  .dd-foot label { display: block; font-size: 11.5px; color: var(--ink-3); margin: 6px 0 2px; }
+  .dd-foot input[type="date"] {
+    width: 100%; font: inherit; font-size: 13px; padding: 4px 6px;
+    border: 1px solid var(--border); border-radius: 6px; background: transparent; color: var(--ink-1);
+  }
+  .dd-foot .btn { margin-top: 9px; width: 100%; }
+  .dd-search { padding: 4px 6px 8px; }
+  .dd-search input {
+    width: 100%; font: inherit; font-size: 13px; padding: 5px 8px;
+    border: 1px solid var(--border); border-radius: 7px; background: transparent; color: var(--ink-1);
+  }
+  .dd-list { max-height: 260px; overflow: auto; }
+  .dd-actions { display: flex; gap: 6px; padding: 2px 6px 6px; }
+  .dd-actions button { flex: 1; font-size: 12px; padding: 4px 6px; }
+  .sw { width: 10px; height: 10px; border-radius: 3px; flex: none; }
+
+  /* ---------- summary card ---------- */
+  .stats { display: grid; grid-template-columns: repeat(4, 1fr); }
+  @media (max-width: 800px) { .stats { grid-template-columns: repeat(2, 1fr); gap: 14px 0; } }
+  .stat { padding: 2px 18px; min-width: 0; }
+  .stat + .stat { border-left: 1px solid var(--grid); }
+  @media (max-width: 800px) { .stat:nth-child(3) { border-left: 0; } }
+  .stat:first-child { padding-left: 4px; }
+  .stat .lbl { font-size: 12px; color: var(--ink-2); }
+  .stat .val { font-size: 25px; font-weight: 650; margin-top: 2px; letter-spacing: -.01em; }
+  .stat .delta { font-size: 12px; margin-top: 1px; }
+  .stat .delta.up { color: var(--good); } .stat .delta.down { color: var(--bad); }
+  .stat .delta .vs { color: var(--ink-3); }
+  .stat svg { display: block; margin-top: 6px; }
+
+  /* ---------- sections & cards ---------- */
+  .section-head { display: flex; align-items: center; gap: 12px; margin: 26px 0 10px; position: relative; z-index: 20; }
+  .section-head h2 { font-size: 15px; font-weight: 650; margin: 0; }
+  .section-head .rule { flex: 1; height: 1px; background: var(--grid); }
+  .card {
+    background: var(--surface-1); border: 1px solid var(--border); border-radius: 12px;
+    padding: 14px 16px 12px; margin-bottom: 14px; min-width: 0;
+  }
+  .card h3 { font-size: 13.5px; font-weight: 650; margin: 0; }
+  .hint { color: var(--ink-3); font-size: 12px; }
+  .card-head { display: flex; align-items: center; gap: 10px; flex-wrap: wrap; margin-bottom: 10px; }
+  .share-flex { display: flex; align-items: center; gap: 22px; flex-wrap: wrap; }
+  .share-flex .bars { flex: 1; min-width: 320px; }
+
+  .chart-wrap { position: relative; }
+  .tooltip {
+    position: absolute; pointer-events: none; display: none; z-index: 20;
+    background: var(--surface-1); border: 1px solid var(--border); border-radius: 10px;
+    box-shadow: 0 8px 28px rgba(0,0,0,.14); padding: 9px 11px; min-width: 190px; font-size: 12.5px;
+  }
+  .tooltip .tt-date { color: var(--ink-3); font-size: 11.5px; margin-bottom: 5px; }
+  .tooltip table { border-collapse: collapse; width: 100%; }
+  .tooltip td { padding: 1.5px 0; }
+  .tooltip td.v { text-align: right; font-weight: 600; font-variant-numeric: tabular-nums; padding-left: 14px; }
+  .tooltip td.n { color: var(--ink-2); }
+  .tooltip .key { display: inline-block; width: 10px; height: 3px; border-radius: 2px; vertical-align: middle; margin-right: 6px; }
+  .tooltip tr.total td { border-top: 1px solid var(--border); padding-top: 4px; font-weight: 650; color: var(--ink-1); }
+
+  .legend { display: flex; flex-wrap: wrap; gap: 4px 6px; margin-top: 10px; }
+  .chip {
+    display: inline-flex; align-items: center; gap: 6px; font-size: 12px; color: var(--ink-2);
+    border: 1px solid var(--border); background: transparent; border-radius: 999px;
+    padding: 3px 10px; cursor: pointer; font-family: inherit;
+  }
+  .chip:hover { background: var(--wash); }
+  .chip.off { opacity: .38; }
+
+  /* ---------- table ---------- */
+  table.prov { width: 100%; border-collapse: collapse; font-size: 13px; }
+  table.prov th {
+    text-align: right; font-weight: 600; color: var(--ink-3); font-size: 11.5px;
+    padding: 6px 10px; border-bottom: 1px solid var(--grid); cursor: pointer; user-select: none; white-space: nowrap;
+  }
+  table.prov th:first-child { text-align: left; }
+  table.prov td { padding: 7px 10px; border-bottom: 1px solid var(--grid); text-align: right; font-variant-numeric: tabular-nums; white-space: nowrap; }
+  table.prov td:first-child { text-align: left; font-variant-numeric: normal; }
+  table.prov tr:last-child td { border-bottom: 0; }
+  table.prov tr:hover td { background: var(--wash); }
+  .pname { display: inline-flex; align-items: center; gap: 8px; color: var(--ink-1); }
+  .share-cell { display: inline-flex; align-items: center; gap: 8px; justify-content: flex-end; }
+  .share-bar { width: 84px; height: 5px; border-radius: 3px; background: var(--grid); overflow: hidden; }
+  .share-bar i { display: block; height: 100%; border-radius: 3px; background: var(--accent); }
+  .muted { color: var(--ink-3); }
+  .dim td { opacity: .5; }
+  .pager { display: flex; align-items: center; gap: 10px; justify-content: flex-end; margin-top: 10px; font-size: 12.5px; color: var(--ink-3); }
+  .pager .btn { padding: 3px 10px; font-size: 12px; }
+  .pager .btn[disabled] { opacity: .4; cursor: default; }
+  select.ps {
+    font: inherit; font-size: 12.5px; color: var(--ink-1); background: var(--surface-1);
+    border: 1px solid var(--border); border-radius: 6px; padding: 2px 6px;
+  }
+  .share-flex svg path { transition: transform .15s ease, opacity .15s ease; }
+  .share-flex .bars g { transition: opacity .15s ease; }
+  .chart-wrap svg [data-s] { transition: opacity .12s ease; }
+
+  /* ---------- notes ---------- */
+  .notes h3 { margin-bottom: 8px; font-size: 13.5px; }
+  .notes h4 { font-size: 12.5px; margin: 14px 0 4px; color: var(--ink-2); }
+  .notes ul { margin: 4px 0 0; padding-left: 18px; color: var(--ink-2); font-size: 13px; }
+  .notes li { margin: 3px 0; }
+  .notes li b { color: var(--ink-1); font-weight: 600; }
+
+  /* ---------- auth / key entry (v2) ---------- */
+  .gate {
+    position: fixed; inset: 0; z-index: 100; display: none;
+    align-items: center; justify-content: center; background: var(--page);
+  }
+  .gate.show { display: flex; }
+  .gate-card {
+    background: var(--surface-1); border: 1px solid var(--border); border-radius: 14px;
+    box-shadow: 0 8px 28px rgba(0,0,0,.12); padding: 26px 26px 22px; width: 340px; max-width: calc(100vw - 32px);
+  }
+  .gate-card .logo { width: 30px; height: 30px; margin-bottom: 12px; }
+  .gate-card h2 { font-size: 17px; font-weight: 650; margin: 0 0 4px; }
+  .gate-card p { color: var(--ink-3); font-size: 12.5px; margin: 0 0 16px; }
+  .gate-card label { display: block; font-size: 12px; color: var(--ink-2); margin-bottom: 5px; }
+  .gate-card input {
+    width: 100%; font: inherit; font-size: 14px; padding: 9px 11px;
+    border: 1px solid var(--border); border-radius: 9px; background: transparent; color: var(--ink-1);
+  }
+  .gate-card .btn { width: 100%; margin-top: 14px; padding: 9px 11px; font-size: 14px; font-weight: 600; }
+  .gate-err { color: var(--bad); font-size: 12.5px; margin-top: 10px; min-height: 16px; }
+  .signout { font-size: 12.5px; }
+
+  /* boot / loading / empty states */
+  #app { display: none; }
+  #app.ready { display: block; }
+  .boot {
+    position: fixed; inset: 0; z-index: 90; display: flex; flex-direction: column;
+    align-items: center; justify-content: center; gap: 10px; background: var(--page); color: var(--ink-3); font-size: 13px;
+  }
+  .boot.hide { display: none; }
+  .spin { width: 22px; height: 22px; border: 2px solid var(--grid); border-top-color: var(--accent); border-radius: 50%; animation: spin .8s linear infinite; }
+  @keyframes spin { to { transform: rotate(360deg); } }
+  .empty { padding: 40px 16px; text-align: center; color: var(--ink-3); font-size: 13px; }
+</style>
+
+<!-- key entry gate: shown when no valid apiKey (fixes v1's silent infinite spinner) -->
+<div class="gate" id="gate">
+  <div class="gate-card">
+    <div class="logo"></div>
+    <h2>Edge Reports</h2>
+    <p>Enter your API key to view the dashboard.</p>
+    <label for="keyInput">API key</label>
+    <input id="keyInput" type="password" autocomplete="off" spellcheck="false" placeholder="API key">
+    <button class="btn" id="keySubmit">View reports</button>
+    <div class="gate-err" id="gateErr"></div>
+  </div>
+</div>
+
+<!-- first-paint boot overlay -->
+<div class="boot" id="boot"><div class="spin"></div><div id="bootMsg">Loading reports…</div></div>
+
+<div id="app">
+<div class="wrap">
+  <header class="top">
+    <div class="logo"></div>
+    <div>
+      <h1>Edge Reports</h1>
+      <div class="sub" id="headerSub">v2 dashboard</div>
+    </div>
+    <div class="spacer"></div>
+    <button class="btn" id="themeBtn" title="Toggle light/dark">◐ Theme</button>
+    <button class="btn signout" id="signOut" title="Clear API key">Sign out</button>
+  </header>
+
+  <!-- global filters: scope everything on the page -->
+  <div class="filters">
+    <div class="dd" id="rangeDD">
+      <button class="btn" id="rangeBtn">▦ Last 30 days ▾</button>
+      <div class="dd-panel" id="rangePanel"></div>
+    </div>
+    <div class="seg" id="typeSeg">
+      <button data-v="all" class="on">All</button>
+      <button data-v="fiat">Fiat buy/sell</button>
+      <button data-v="swap">Swap</button>
+    </div>
+    <div class="dd" id="provDD">
+      <button class="btn" id="provBtn">All providers ▾</button>
+      <div class="dd-panel" style="min-width:250px">
+        <div class="dd-search"><input id="provSearch" placeholder="Search providers…"></div>
+        <div class="dd-actions">
+          <button class="btn" id="provAll">Select all</button>
+          <button class="btn" id="provNone">Clear</button>
+        </div>
+        <div class="dd-list" id="provList"></div>
+      </div>
+    </div>
+    <div class="dd" id="pairDD">
+      <button class="btn" id="pairBtn">All pairs ▾</button>
+      <div class="dd-panel" style="min-width:230px">
+        <div class="dd-search"><input id="pairSearch" placeholder="Search pairs…"></div>
+        <div class="dd-actions">
+          <button class="btn" id="pairAll">Select all</button>
+          <button class="btn" id="pairNone">Clear</button>
+        </div>
+        <div class="dd-list" id="pairList"></div>
+      </div>
+    </div>
+    <div class="spacer"></div>
+    <span class="hint" id="granHint"></span>
+  </div>
+
+  <!-- one summary card -->
+  <div class="card">
+    <div class="stats" id="stats"></div>
+  </div>
+
+  <!-- ================= PROVIDERS ================= -->
+  <div class="section-head">
+    <h2>Providers</h2>
+    <div class="rule"></div>
+  </div>
+
+  <div class="card">
+    <div class="card-head">
+      <h3 id="provTrendTitle">Volume by provider</h3>
+      <div class="spacer"></div>
+      <div class="seg" id="metricSeg">
+        <button data-v="volume" class="on">Volume</button>
+        <button data-v="revenue">Est. revenue</button>
+        <button data-v="txs">Transactions</button>
+      </div>
+      <div class="seg" id="provChartSeg">
+        <button data-v="stacked" class="on">Stacked</button>
+        <button data-v="lines">Lines</button>
+      </div>
+      <label class="hint" style="display:inline-flex;align-items:center;gap:6px;cursor:pointer">
+        <input type="checkbox" id="provOther" checked> include other
+      </label>
+    </div>
+    <div class="chart-wrap">
+      <svg id="provTrend" width="100%" height="320"></svg>
+      <div class="tooltip" id="provTT"></div>
+    </div>
+    <div class="legend" id="provLegend"></div>
+  </div>
+
+  <div class="card">
+    <div class="card-head">
+      <h3>Provider share</h3>
+      <span class="hint">of <span id="provShareMetricLbl">volume</span> in range · same top 8 + other as the chart above</span>
+      <div class="spacer"></div>
+      <label class="hint" style="display:inline-flex;align-items:center;gap:6px;cursor:pointer">
+        <input type="checkbox" id="provShareOtherCb" checked> include other
+      </label>
+    </div>
+    <div class="share-flex">
+      <svg id="provDonut" width="200" height="200"></svg>
+      <div class="bars"><svg id="provBars" width="100%"></svg></div>
+    </div>
+  </div>
+
+  <div class="card">
+    <div class="card-head">
+      <h3>Provider detail</h3>
+      <span class="hint" id="provCount"></span>
+      <div class="spacer"></div>
+      <label class="hint" style="display:inline-flex;align-items:center;gap:6px;cursor:pointer">
+        <input type="checkbox" id="showInactive"> show inactive providers
+      </label>
+    </div>
+    <div style="overflow-x:auto">
+      <table class="prov" id="provTable"></table>
+    </div>
+  </div>
+
+  <!-- ================= CURRENCY PAIRS ================= -->
+  <div class="section-head">
+    <h2>Currency pairs</h2>
+    <div class="rule"></div>
+  </div>
+
+  <div class="card">
+    <div class="card-head">
+      <h3>Volume by pair</h3>
+      <span class="hint">across selected providers</span>
+      <div class="spacer"></div>
+      <div class="seg" id="pairChartSeg">
+        <button data-v="stacked" class="on">Stacked</button>
+        <button data-v="lines">Lines</button>
+      </div>
+      <label class="hint" style="display:inline-flex;align-items:center;gap:6px;cursor:pointer">
+        <input type="checkbox" id="pairOther" checked> include other
+      </label>
+    </div>
+    <div class="chart-wrap">
+      <svg id="pairTrend" width="100%" height="300"></svg>
+      <div class="tooltip" id="pairTT"></div>
+    </div>
+    <div class="legend" id="pairLegend"></div>
+  </div>
+
+  <div class="card">
+    <div class="card-head">
+      <h3>Pair share</h3>
+      <span class="hint">of volume in range · same top 8 + other as the chart above</span>
+      <div class="spacer"></div>
+      <label class="hint" style="display:inline-flex;align-items:center;gap:6px;cursor:pointer">
+        <input type="checkbox" id="pairShareOtherCb" checked> include other
+      </label>
+    </div>
+    <div class="share-flex">
+      <svg id="pairDonut" width="200" height="200"></svg>
+      <div class="bars"><svg id="pairBars" width="100%"></svg></div>
+    </div>
+  </div>
+
+  <div class="card">
+    <div class="card-head">
+      <h3>Pair detail</h3>
+      <span class="hint" id="pairCount"></span>
+      <div class="spacer"></div>
+      <label class="hint" style="display:inline-flex;align-items:center;gap:6px">
+        rows per page
+        <select class="ps" id="pairPageSize">
+          <option value="10" selected>10</option>
+          <option value="25">25</option>
+          <option value="50">50</option>
+        </select>
+      </label>
+    </div>
+    <div style="overflow-x:auto">
+      <table class="prov" id="pairTable"></table>
+    </div>
+    <div class="pager" id="pairPager"></div>
+  </div>
+
+  <div class="card notes">
+    <h3>What changed vs the current site, and why</h3>
+    <ul>
+      <li><b>Two entity groups, one top-level filter row, every filter scopes every card.</b> The page is grouped into Providers and Currency pairs, and all four filters (range, type, providers, pairs) apply to the whole page including the summary. One data caveat: the API records volume per pair but not transactions per pair, so under a pair filter each provider's txs (and avg tx) are estimated by scaling its tx count by that pair share of its volume.</li>
+      <li><b>Revenue is a first-class metric.</b> The current site only shows gross volume. This design applies a per-provider rev-share rate to volume (rates editable in config) and shows Est. revenue in the summary, the provider trend, and the table. Data requirement: the analytics response has no revenue field today; either compute client-side from a rates map or add it to the cache/API.</li>
+      <li><b>Trend + share pairing.</b> Each group gets a time-series card (stacked bars or lines per entity), a share card (donut for at-a-glance proportion, ranked horizontal bars for exact comparison), and a detail table (the pair table is paginated with a rows-per-page control). No dual-axis charts anywhere; the metric toggle swaps the whole view instead.</li>
+      <li><b>Hover to focus, filter only up top.</b> Legend pills highlight their series on hover (everything else dims) instead of mutating the global filter; the donut and ranked bars in each share card are hover-linked (a segment pops out and its row highlights, and vice versa). Share cards show exactly the same top 8 + Other split as their trend chart, and every trend and share card has its own local "include other" checkbox that hides the folded tail from that card only (share totals and percentages recompute over what is shown).</li>
+      <li><b>Number formatting.</b> Compact in tiles, axes and bars ($40.7M), full precision in tooltips and the table. Clean rounded axis ticks.</li>
+      <li><b>Color discipline.</b> 8 CVD-validated series colors per group, assigned to the top 8 entities of the current view (its range, filters and metric), so the trend chart, share card and detail table always agree on who is "Other". The tail folds into gray. The 40-swatch legend with five near-black providers goes away.</li>
+      <li><b>Range selection.</b> One preset dropdown (rows, not a calendar grid) with a custom range in the footer; granularity picks itself from range length.</li>
+      <li><b>The mini-chart wall</b> becomes a sortable detail table with share bars, sparklines and avg tx size, and doubles as the accessible table view. Inactive providers hidden behind a toggle.</li>
+    </ul>
+    <h4>Data source</h4>
+    <ul>
+      <li>Live data from the <b>/v1</b> reporting API: <b>getAppId</b> (apiKey auth), <b>getPluginIds</b> (provider list) and one <b>analytics</b> POST (daily buckets, last 24 months) for all providers at once. Est. revenue is derived client-side from the per-provider rev-share rates in server config (<b>/v2/config</b>); the analytics response has no revenue field.</li>
+      <li>A bad or missing API key now redirects to the key-entry screen instead of hanging: getAppId returns plain text on 400, so the response is checked before parsing and fetch errors are surfaced.</li>
+      <li>Pair transactions are not recorded by the API (only pair volume), so under a pair filter each provider's txs and avg tx are estimated by scaling its tx count by that pair's share of its volume.</li>
+    </ul>
+  </div>
+</div>
+</div><!-- /#app -->
+
+<script>
+'use strict';
+/* ================================================================
+   Edge Reports v2 — live data layer
+
+   The rendering + interaction engine below is ported verbatim from the
+   design prototype. Only the data source changed: the prototype's
+   deterministic sample generator is replaced by the real /v1 reporting
+   API. Everything the engine consumes is still just two structures,
+   PROVIDERS[] and daily[][], built here from API responses.
+   ================================================================ */
+
+const DAY = 864e5;
+const DAYS = 730; // 24 months of daily buckets, matching the widest preset
+
+// API is same-origin (indexApi serves this bundle and the /v1 + /v2 routes).
+const API_BASE = '';
+
+// Real "today" at UTC midnight; the daily array is a contiguous DAYS-long
+// window ending today. Buckets are keyed by their UTC calendar day so the
+// mapping is timezone-safe regardless of where the browser runs.
+const _now = new Date();
+const TODAY = new Date(_now.getFullYear(), _now.getMonth(), _now.getDate());
+const utcDayIndex = ms => {
+  const d = new Date(ms);
+  return Math.floor(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate()) / DAY);
+};
+const TODAY_DAY_INDEX = utcDayIndex(_now.getTime());
+
+/* ---------------- cookies ---------------- */
+function getCookie(name) {
+  const m = document.cookie.match('(?:^|; )' + name.replace(/([.$?*|{}()[\]\\/+^])/g, '\\$1') + '=([^;]*)');
+  return m ? decodeURIComponent(m[1]) : null;
+}
+function setCookie(name, value, days) {
+  const exp = new Date(Date.now() + (days || 365) * DAY).toUTCString();
+  document.cookie = name + '=' + encodeURIComponent(value) + '; path=/; expires=' + exp + '; SameSite=Lax';
+}
+function clearCookie(name) {
+  document.cookie = name + '=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT';
+}
+
+/* ---------------- API layer ---------------- */
+class AuthError extends Error {}
+
+// getAppId returns PLAIN TEXT on a bad key (400) and JSON on success. v1 called
+// response.json() unconditionally, which threw on the 400 body and left the page
+// spinning forever. Here a non-2xx is turned into an AuthError so the caller can
+// redirect to the key screen.
+async function apiGetAppId(apiKey) {
+  const res = await fetch(API_BASE + '/v1/getAppId/?apiKey=' + encodeURIComponent(apiKey));
+  if (!res.ok) throw new AuthError('Invalid API key');
+  return res.json();
+}
+async function apiGetConfig(apiKey) {
+  const res = await fetch(API_BASE + '/v2/config/?apiKey=' + encodeURIComponent(apiKey));
+  if (res.status === 401 || res.status === 400) throw new AuthError('Invalid API key');
+  if (!res.ok) throw new Error('Failed to load config (' + res.status + ')');
+  return res.json();
+}
+async function apiGetPluginIds(apiKey) {
+  const res = await fetch(API_BASE + '/v1/getPluginIds/?apiKey=' + encodeURIComponent(apiKey));
+  if (res.status === 401 || res.status === 400) throw new AuthError('Invalid API key');
+  if (res.status === 404) return []; // app has no partners registered yet
+  if (!res.ok) throw new Error('Failed to load providers (' + res.status + ')');
+  return res.json();
+}
+async function apiAnalytics(apiKey, pluginIds, startIso, endIso) {
+  const res = await fetch(API_BASE + '/v1/analytics/', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ start: startIso, end: endIso, apiKey, pluginIds, timePeriod: 'day' })
+  });
+  if (res.status === 401 || res.status === 400) throw new AuthError('Invalid API key');
+  if (!res.ok) throw new Error('Failed to load analytics (' + res.status + ')');
+  return res.json();
+}
+
+/* ---------------- runtime data (filled by loadData) ---------------- */
+let PROVIDERS = [];
+let daily = [];
+let REV_SHARE = {};       // pluginId -> rev-share fraction
+let PROVIDER_TYPES = {};  // pluginId -> 'fiat' | 'swap'
+let PAIR_RANKED = [];     // pair names, ranked by recent volume (filter order)
+let ALL_PAIR_NAMES = [];  // every pair seen
+
+const PROVIDER_DISPLAY = { lifi: 'LI.FI', btcx: 'BTCx', nym: 'NYM' };
+function displayName(pluginId) {
+  if (PROVIDER_DISPLAY[pluginId]) return PROVIDER_DISPLAY[pluginId];
+  return pluginId.charAt(0).toUpperCase() + pluginId.slice(1);
+}
+
+// Turn one partner's analytics day buckets into a contiguous DAYS-long array of
+// { t, usd, txs, pairs } aligned to the shared TODAY window.
+function buildProviderDaily(dayBuckets) {
+  const arr = new Array(DAYS);
+  for (let idx = 0; idx < DAYS; idx++) {
+    arr[idx] = { t: new Date(TODAY.getTime() - (DAYS - 1 - idx) * DAY), usd: 0, txs: 0, pairs: {} };
+  }
+  for (const b of dayBuckets) {
+    const bucketDayIndex = utcDayIndex(b.start * 1000); // bucket.start is seconds
+    const idx = DAYS - 1 - (TODAY_DAY_INDEX - bucketDayIndex);
+    if (idx < 0 || idx >= DAYS) continue;
+    const slot = arr[idx];
+    slot.usd += b.usdValue || 0;
+    slot.txs += b.numTxs || 0;
+    const pairs = b.currencyPairs || {};
+    for (const k in pairs) slot.pairs[k] = (slot.pairs[k] || 0) + pairs[k];
+  }
+  return arr;
+}
+
+async function loadData(apiKey) {
+  const [cfg, pluginIds] = await Promise.all([apiGetConfig(apiKey), apiGetPluginIds(apiKey)]);
+  REV_SHARE = cfg.revShareRates || {};
+  PROVIDER_TYPES = cfg.providerTypes || {};
+
+  const startIso = new Date(TODAY.getTime() - (DAYS - 1) * DAY).toISOString();
+  const endIso = new Date(TODAY.getTime() + DAY).toISOString();
+
+  const analytics = pluginIds.length > 0
+    ? await apiAnalytics(apiKey, pluginIds, startIso, endIso)
+    : [];
+  const byPartner = {};
+  for (const entry of analytics) byPartner[entry.partnerId] = entry;
+
+  PROVIDERS = pluginIds.map((pluginId, i) => ({
+    name: displayName(pluginId),
+    id: pluginId,
+    type: PROVIDER_TYPES[pluginId] === 'fiat' ? 'fiat' : 'swap',
+    rr: REV_SHARE[pluginId] || 0,
+    active: false, // set below once volume is known
+    i
+  }));
+  daily = PROVIDERS.map(p => {
+    const entry = byPartner[p.id];
+    return buildProviderDaily(entry && entry.result ? entry.result.day || [] : []);
+  });
+  // A provider is "active" if it moved any volume in the loaded window.
+  PROVIDERS.forEach(p => { p.active = daily[p.i].some(b => b.usd > 0); });
+
+  initDerived();
+}
+
+// pair rankings + master lists, recomputed from the loaded data (was static in
+// the prototype). Rank by the most recent 90 days so the filter list is stable.
+function initDerived() {
+  const pairTotals = {};
+  for (const p of PROVIDERS) {
+    if (!p.active) continue;
+    for (const b of daily[p.i].slice(-90)) {
+      for (const k in b.pairs) pairTotals[k] = (pairTotals[k] || 0) + b.pairs[k];
+    }
+  }
+  const allPairs = new Set();
+  for (const p of PROVIDERS) {
+    if (!p.active) continue;
+    for (const b of daily[p.i]) for (const k in b.pairs) allPairs.add(k);
+  }
+  ALL_PAIR_NAMES = [...allPairs];
+  PAIR_RANKED = [...allPairs].sort((a, b) => (pairTotals[b] || 0) - (pairTotals[a] || 0));
+}
+
+
+/* ---------------- formatting ---------------- */
+const fmtMoney = v => {
+  const a = Math.abs(v);
+  if (a >= 1e9) return '$' + (v/1e9).toFixed(a >= 1e10 ? 0 : 1) + 'B';
+  if (a >= 1e6) return '$' + (v/1e6).toFixed(a >= 1e8 ? 0 : 1) + 'M';
+  if (a >= 1e3) return '$' + (v/1e3).toFixed(a >= 1e5 ? 0 : 1) + 'K';
+  return '$' + Math.round(v);
+};
+const fmtMoneyFull = v => '$' + Math.round(v).toLocaleString('en-US');
+const fmtNum = v => {
+  const a = Math.abs(v);
+  if (a >= 1e6) return (v/1e6).toFixed(1) + 'M';
+  if (a >= 1e4) return (v/1e3).toFixed(1) + 'K';
+  return Math.round(v).toLocaleString('en-US');
+};
+const fmtPct = v => (v >= 0 ? '+' : '') + (v*100).toFixed(1) + '%';
+const MONTHS = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'];
+const fmtDate = (d, gran) =>
+  gran === 'month' ? MONTHS[d.getMonth()] + ' ’' + String(d.getFullYear()).slice(2)
+  : MONTHS[d.getMonth()] + ' ' + d.getDate();
+
+/* ---------------- state ---------------- */
+const PRESETS = [
+  { id:'7d',  label:'Last 7 days',   days:7,   gran:'day' },
+  { id:'30d', label:'Last 30 days',  days:30,  gran:'day' },
+  { id:'90d', label:'Last 90 days',  days:90,  gran:'day' },
+  { id:'qtd', label:'This quarter',  days:31,  gran:'day' },
+  { id:'12m', label:'Last 12 months',days:365, gran:'month' },
+  { id:'24m', label:'Last 24 months',days:730, gran:'month' },
+];
+const state = {
+  preset: '30d', custom: null,
+  metric: 'volume', type: 'all',
+  provChart: 'stacked', pairChart: 'stacked',
+  enabled: new Set(),      // filled in boot() once providers load
+  enabledPairs: new Set(), // filled in boot() once pairs load
+  showInactive: false,
+  sortBy: 'vol', sortDir: -1,
+  pairSortBy: 'vol', pairSortDir: -1,
+  pairPage: 0, pairPageSize: 10,
+  provShowOther: true, pairShowOther: true,
+  provShareOther: true, pairShareOther: true,
+  provSearch: '', pairSearch: '',
+};
+
+/* ---------------- data slicing ---------------- */
+function rangeDays() {
+  if (state.custom) {
+    const s = Math.max(0, Math.floor((TODAY - state.custom[0]) / DAY));
+    const e = Math.max(0, Math.floor((TODAY - state.custom[1]) / DAY));
+    return { from: s, to: e, gran: (s - e) > 120 ? 'month' : 'day' };
+  }
+  const p = PRESETS.find(p => p.id === state.preset);
+  return { from: p.days - 1, to: 0, gran: p.gran };
+}
+const typeMatch = p => state.type === 'all' || p.type === state.type;
+
+// pair-filtered slice of one bucket: volume over enabled pairs, txs scaled by pair share
+function bucketSlice(b) {
+  let pv = 0, tot = 0;
+  for (const k in b.pairs) { tot += b.pairs[k]; if (state.enabledPairs.has(k)) pv += b.pairs[k]; }
+  return { vol: pv, txs: tot > 0 ? b.txs * pv / tot : 0 };
+}
+function providerRows(daysBack) { // per-provider aggregates over the window (type- and pair-filtered)
+  const { from, to } = daysBack;
+  return PROVIDERS.filter(p => p.active && typeMatch(p)).map(p => {
+    let usd = 0, txs = 0;
+    const arr = daily[p.i];
+    for (let d = DAYS - 1 - from; d <= DAYS - 1 - to; d++) {
+      const b = arr[d]; if (!b) continue;
+      const s = bucketSlice(b);
+      usd += s.vol; txs += s.txs;
+    }
+    return { p, usd, txs, rev: usd * p.rr };
+  });
+}
+function provBuckets(daysBack) { // time buckets per enabled provider
+  const { from, to, gran } = daysBack;
+  const provs = PROVIDERS.filter(p => p.active && typeMatch(p) && state.enabled.has(p.name));
+  const out = [], seen = {};
+  for (let d = from; d >= to; d--) {
+    const t = new Date(TODAY.getTime() - d * DAY);
+    let slot;
+    if (gran === 'day') { slot = { t, vals: {} }; out.push(slot); }
+    else {
+      const key = t.getFullYear() + '-' + t.getMonth();
+      if (!seen[key]) { seen[key] = { t: new Date(t.getFullYear(), t.getMonth(), 1), vals: {} }; out.push(seen[key]); }
+      slot = seen[key];
+    }
+    for (const p of provs) {
+      const b = daily[p.i][DAYS - 1 - d]; if (!b) continue;
+      const s = bucketSlice(b);
+      const v = slot.vals[p.name] || (slot.vals[p.name] = { usd: 0, txs: 0, rev: 0 });
+      v.usd += s.vol; v.txs += s.txs; v.rev += s.vol * p.rr;
+    }
+  }
+  return { out, gran };
+}
+function pairAgg(daysBack) { // per-pair totals over the window (cascades from provider selection)
+  const { from, to } = daysBack;
+  const agg = {};
+  for (const p of PROVIDERS.filter(p => p.active && typeMatch(p) && state.enabled.has(p.name))) {
+    for (let d = from; d >= to; d--) {
+      const b = daily[p.i][DAYS - 1 - d]; if (!b) continue;
+      for (const k in b.pairs) {
+        if (!state.enabledPairs.has(k)) continue;
+        agg[k] = (agg[k] || 0) + b.pairs[k];
+      }
+    }
+  }
+  return agg;
+}
+function pairBuckets(daysBack) { // time buckets per enabled pair (cascades from provider selection)
+  const { from, to, gran } = daysBack;
+  const provs = PROVIDERS.filter(p => p.active && typeMatch(p) && state.enabled.has(p.name));
+  const out = [], seen = {};
+  for (let d = from; d >= to; d--) {
+    const t = new Date(TODAY.getTime() - d * DAY);
+    let slot;
+    if (gran === 'day') { slot = { t, vals: {} }; out.push(slot); }
+    else {
+      const key = t.getFullYear() + '-' + t.getMonth();
+      if (!seen[key]) { seen[key] = { t: new Date(t.getFullYear(), t.getMonth(), 1), vals: {} }; out.push(seen[key]); }
+      slot = seen[key];
+    }
+    for (const p of provs) {
+      const b = daily[p.i][DAYS - 1 - d]; if (!b) continue;
+      for (const k in b.pairs) {
+        if (!state.enabledPairs.has(k)) continue;
+        slot.vals[k] = (slot.vals[k] || 0) + b.pairs[k];
+      }
+    }
+  }
+  return { out, gran };
+}
+const metricOf = (v, m) => m === 'volume' ? v.usd : m === 'revenue' ? v.rev : v.txs;
+const fmtMetric = (v, m) => m === 'txs' ? fmtNum(v) : fmtMoney(v);
+const fmtMetricFull = (v, m) => m === 'txs' ? Math.round(v).toLocaleString('en-US') : fmtMoneyFull(v);
+
+/* color slots per group: top 8 of the CURRENT view (range, type, provider and pair
+   selection, and the selected metric for providers). Slots re-rank when the view
+   changes so the chart, share card and detail table always agree on who is "Other". */
+let SLOT = {}, PAIRSLOT = {};
+const colorOf = name => SLOT[name] ? `var(--s${SLOT[name]})` : 'var(--other)';
+const colorOfPair = name => PAIRSLOT[name] ? `var(--s${PAIRSLOT[name]})` : 'var(--other)';
+function computeSlots() {
+  const db = rangeDays();
+  const rows = providerRows(db).filter(r => state.enabled.has(r.p.name))
+    .map(r => ({ n: r.p.name, v: metricOf({ usd: r.usd, rev: r.rev, txs: r.txs }, state.metric) }))
+    .sort((a, b) => b.v - a.v);
+  SLOT = {}; rows.slice(0, 8).forEach((r, i) => SLOT[r.n] = i + 1);
+  const prs = Object.entries(pairAgg(db)).sort((a, b) => b[1] - a[1]);
+  PAIRSLOT = {}; prs.slice(0, 8).forEach((e, i) => PAIRSLOT[e[0]] = i + 1);
+}
+
+/* PAIR_RANKED (stable pair ordering for the filter dropdown) is computed in
+   initDerived() once the live data has loaded. */
+
+/* ---------------- svg helpers ---------------- */
+const NS = 'http://www.w3.org/2000/svg';
+function el(tag, attrs, parent) {
+  const e = document.createElementNS(NS, tag);
+  for (const k in attrs) e.setAttribute(k, attrs[k]);
+  if (parent) parent.appendChild(e);
+  return e;
+}
+function niceTicks(max, n = 4) {
+  if (max <= 0) return [0, 1];
+  const raw = max / n, mag = Math.pow(10, Math.floor(Math.log10(raw)));
+  const step = [1, 2, 2.5, 5, 10].map(m => m * mag).find(s => s * n >= max) || 10 * mag;
+  const ticks = []; for (let v = 0; v <= max + 1e-9; v += step) ticks.push(v);
+  if (ticks[ticks.length-1] < max) ticks.push(ticks[ticks.length-1] + step);
+  return ticks;
+}
+function roundTopBarPath(x, y, w, h, r) {
+  return `M${x} ${y + h}V${y + r}Q${x} ${y} ${x + r} ${y}H${x + w - r}Q${x + w} ${y} ${x + w} ${y + r}V${y + h}Z`;
+}
+function roundEndBarPath(x, y, w, h, r) { // horizontal, rounded right end
+  return `M${x} ${y}H${x + w - r}Q${x + w} ${y} ${x + w} ${y + r}V${y + h - r}Q${x + w} ${y + h} ${x + w - r} ${y + h}H${x}Z`;
+}
+
+/* ---------------- summary card ---------------- */
+/* one resampling rule for every mini trend line: split the full range into n
+   equal-width buckets and take the MEAN of each, so a partial trailing chunk
+   never fakes a dip and every sparkline spans its box edge to edge */
+function trendPoints(dayVals, n) {
+  const N = dayVals.length;
+  if (N === 0) return [0, 0];
+  if (N <= n) return dayVals.slice();
+  const pts = [];
+  for (let i = 0; i < n; i++) {
+    const a = Math.floor(i * N / n), b = Math.max(a + 1, Math.floor((i + 1) * N / n));
+    let s = 0; for (let j = a; j < b; j++) s += dayVals[j];
+    pts.push(s / (b - a));
+  }
+  return pts;
+}
+function sparkline(points, w, h, color) {
+  const max = Math.max(...points, 1e-9), min = Math.min(...points, 0);
+  const svg = document.createElementNS(NS, 'svg');
+  svg.setAttribute('width', w); svg.setAttribute('height', h);
+  const x = i => 2 + i * (w - 4) / (points.length - 1);
+  const y = v => h - 3 - (v - min) / (max - min || 1) * (h - 6);
+  const line = points.map((v, i) => (i ? 'L' : 'M') + x(i).toFixed(1) + ' ' + y(v).toFixed(1)).join(' ');
+  const last = points.length - 1;
+  el('path', {
+    d: line + `L${x(last).toFixed(1)} ${h - 1}L${x(0).toFixed(1)} ${h - 1}Z`,
+    fill: color, 'fill-opacity': .13, stroke: 'none',
+  }, svg);
+  el('path', { d: line, fill:'none', stroke: color, 'stroke-width':1.5, 'stroke-linejoin':'round', 'stroke-linecap':'round' }, svg);
+  el('circle', { cx:x(last), cy:y(points[last]), r:3, fill: color, stroke:'var(--surface-1)', 'stroke-width':2 }, svg);
+  return svg;
+}
+function renderSummary() {
+  const db = rangeDays();
+  const enabledOnly = rows => rows.filter(r => state.enabled.has(r.p.name));
+  const cur = enabledOnly(providerRows(db));
+  const span = db.from - db.to + 1;
+  const prev = enabledOnly(providerRows({ from: db.from + span, to: db.to + span, gran: db.gran }));
+  const sum = (rows, k) => rows.reduce((s, r) => s + r[k], 0);
+  const vol = sum(cur,'usd'), rev = sum(cur,'rev'), txs = sum(cur,'txs');
+  const pVol = sum(prev,'usd'), pRev = sum(prev,'rev'), pTxs = sum(prev,'txs');
+  const avg = txs ? vol / txs : 0, pAvg = pTxs ? pVol / pTxs : 0;
+
+  // 12-point sparklines across the range, per stat, fully filtered
+  const days = [];
+  for (let d = db.from; d >= db.to; d--) {
+    let v = 0, t = 0, r = 0;
+    for (const p of PROVIDERS.filter(p => p.active && typeMatch(p) && state.enabled.has(p.name))) {
+      const b = daily[p.i][DAYS - 1 - d]; if (!b) continue;
+      const s = bucketSlice(b);
+      v += s.vol; t += s.txs; r += s.vol * p.rr;
+    }
+    days.push({ v, t, r });
+  }
+  const stats = [
+    { lbl:'Volume', val: fmtMoney(vol), d: pVol ? (vol-pVol)/pVol : null, spark: days.map(x => x.v), color: 'var(--s1)' },
+    { lbl:'Est. revenue', val: fmtMoney(rev), d: pRev ? (rev-pRev)/pRev : null, spark: days.map(x => x.r), color: 'var(--s3)' },
+    { lbl:'Transactions', val: fmtNum(txs), d: pTxs ? (txs-pTxs)/pTxs : null, spark: days.map(x => x.t), color: 'var(--s7)' },
+    { lbl:'Avg transaction', val: fmtMoney(avg), d: pAvg ? (avg-pAvg)/pAvg : null, spark: days.map(x => x.t ? x.v / x.t : 0), color: 'var(--s2)' },
+  ];
+  const root = document.getElementById('stats');
+  root.textContent = '';
+  for (const t of stats) {
+    const box = document.createElement('div'); box.className = 'stat';
+    const lbl = document.createElement('div'); lbl.className = 'lbl'; lbl.textContent = t.lbl;
+    const val = document.createElement('div'); val.className = 'val'; val.textContent = t.val;
+    box.append(lbl, val);
+    if (t.d != null) {
+      const d = document.createElement('div');
+      d.className = 'delta ' + (t.d >= 0 ? 'up' : 'down');
+      d.textContent = fmtPct(t.d) + ' ';
+      const vs = document.createElement('span'); vs.className = 'vs'; vs.textContent = 'vs prior period';
+      d.appendChild(vs);
+      box.appendChild(d);
+    }
+    root.appendChild(box); // attach first so the box has a measurable width
+    if (t.spark) {
+      const w = Math.max(120, box.clientWidth - 30);
+      const n = Math.max(12, Math.min(40, Math.floor(w / 8)));
+      box.appendChild(sparkline(trendPoints(t.spark, n), w, 28, t.color));
+    }
+  }
+}
+
+/* ---------------- generic time-series chart ---------------- */
+const M = { l: 56, r: 16, t: 12, b: 26 };
+
+function foldSeries(presentNames, slotMap) {
+  const tops = presentNames.filter(n => slotMap[n]).sort((a, b) => slotMap[a] - slotMap[b]);
+  const others = presentNames.filter(n => !slotMap[n]);
+  return { tops, others };
+}
+function drawTimeSeries(svg, ttEl, cfg) {
+  // cfg: out [{t, vals}], gran, chartType, valueOf(name, bucket)->number,
+  //      colorFn, fmtV, fmtVFull, seriesFold {tops, others}
+  svg.textContent = '';
+  const W = svg.clientWidth || 900, H = +svg.getAttribute('height');
+  svg.setAttribute('viewBox', `0 0 ${W} ${H}`);
+  const { out, gran, chartType, colorFn, fmtV, fmtVFull } = cfg;
+  const { tops, others } = cfg.seriesFold;
+  const names = others.length ? [...tops, 'Other'] : tops;
+
+  const stacksPer = out.map(b => {
+    const per = tops.map(n => ({ n, v: cfg.valueOf(n, b) }));
+    if (others.length) per.push({ n: 'Other', v: others.reduce((s, n) => s + cfg.valueOf(n, b), 0) });
+    return per;
+  });
+
+  const plotW = W - M.l - M.r, plotH = H - M.t - M.b;
+  const x = i => M.l + (i + .5) * plotW / out.length;
+  let maxV;
+  if (chartType === 'stacked') maxV = Math.max(...stacksPer.map(s => s.reduce((a, r) => a + r.v, 0)), 1e-9);
+  else maxV = Math.max(...stacksPer.flat().map(r => r.v), 1e-9);
+  const ticks = niceTicks(maxV);
+  const top = ticks[ticks.length - 1];
+  const y = v => M.t + plotH - v / top * plotH;
+
+  for (const tv of ticks) {
+    el('line', { x1: M.l, x2: W - M.r, y1: y(tv), y2: y(tv), stroke: tv === 0 ? 'var(--axis)' : 'var(--grid)', 'stroke-width': 1 }, svg);
+    const t = el('text', { x: M.l - 8, y: y(tv) + 4, 'text-anchor': 'end', 'font-size': 11, fill: 'var(--ink-3)' }, svg);
+    t.textContent = fmtV(tv);
+  }
+  const every = Math.ceil(out.length / Math.floor(plotW / 78));
+  const lastRegular = Math.floor((out.length - 1) / every) * every;
+  out.forEach((b, i) => {
+    if (i % every !== 0 && i !== out.length - 1) return;
+    if (i === out.length - 1 && i % every !== 0 && (i - lastRegular) * plotW / out.length < 58) return;
+    const t = el('text', { x: x(i), y: H - 8, 'text-anchor': 'middle', 'font-size': 11, fill: 'var(--ink-3)' }, svg);
+    t.textContent = fmtDate(b.t, gran);
+  });
+
+  if (chartType === 'stacked') {
+    const bw = Math.min(24, Math.max(3, plotW / out.length - 2));
+    let peakI = 0, peakV = 0;
+    stacksPer.forEach((s, i) => { const tot = s.reduce((a, r) => a + r.v, 0); if (tot > peakV) { peakV = tot; peakI = i; } });
+    stacksPer.forEach((segs, i) => {
+      let acc = 0;
+      const drawn = segs.filter(s => s.v > 0);
+      drawn.forEach((s, si) => {
+        const y1 = y(acc + s.v), y0 = y(acc);
+        const hh = Math.max(0, y0 - y1 - (si < drawn.length - 1 ? 2 : 0)); // 2px surface gap
+        const fill = s.n === 'Other' ? 'var(--other)' : colorFn(s.n);
+        if (si === drawn.length - 1) {
+          const r = Math.min(4, bw / 2);
+          el('path', { d: roundTopBarPath(x(i) - bw / 2, y1, bw, hh, r), fill, 'data-s': s.n }, svg);
+        } else {
+          el('rect', { x: x(i) - bw / 2, y: y1, width: bw, height: hh, fill, 'data-s': s.n }, svg);
+        }
+        acc += s.v;
+      });
+      if (i === peakI && out.length > 6) {
+        const t = el('text', { x: x(i), y: y(peakV) - 6, 'text-anchor': 'middle', 'font-size': 11, 'font-weight': 600, fill: 'var(--ink-2)' }, svg);
+        t.textContent = fmtV(peakV);
+      }
+    });
+  } else {
+    names.forEach(n => {
+      const pts = stacksPer.map((s, i) => [x(i), y((s.find(r => r.n === n) || { v: 0 }).v)]);
+      const d = pts.map((p, i) => (i ? 'L' : 'M') + p[0].toFixed(1) + ' ' + p[1].toFixed(1)).join(' ');
+      const c = n === 'Other' ? 'var(--other)' : colorFn(n);
+      el('path', { d, fill: 'none', stroke: c, 'stroke-width': 2, 'stroke-linejoin': 'round', 'stroke-linecap': 'round', 'data-s': n }, svg);
+      const lastPt = pts[pts.length - 1];
+      el('circle', { cx: lastPt[0], cy: lastPt[1], r: 4, fill: c, stroke: 'var(--surface-1)', 'stroke-width': 2, 'data-s': n }, svg);
+    });
+    const ends = names.map(n => ({ n, v: (stacksPer[stacksPer.length - 1].find(r => r.n === n) || { v: 0 }).v }))
+      .sort((a, b) => b.v - a.v).slice(0, 3);
+    const used = [];
+    for (const e of ends) {
+      const yy = y(e.v);
+      if (used.some(u => Math.abs(u - yy) < 13)) continue;
+      used.push(yy);
+      const t = el('text', { x: W - M.r - 2, y: yy + 4, 'text-anchor': 'end', 'font-size': 11, 'font-weight': 600, fill: 'var(--ink-2)', 'data-s': e.n }, svg);
+      t.textContent = e.n;
+    }
+  }
+
+  // hover: crosshair + all-series tooltip
+  const cross = el('line', { y1: M.t, y2: H - M.b, stroke: 'var(--axis)', 'stroke-width': 1, visibility: 'hidden' }, svg);
+  const wrap = svg.parentElement;
+  svg.onpointermove = ev => {
+    const r = svg.getBoundingClientRect();
+    const px = (ev.clientX - r.left) * (W / r.width);
+    let best = 0, bd = 1e9;
+    out.forEach((b, i) => { const d = Math.abs(x(i) - px); if (d < bd) { bd = d; best = i; } });
+    cross.setAttribute('x1', x(best)); cross.setAttribute('x2', x(best));
+    cross.setAttribute('visibility', 'visible');
+    const rowsAll = [...stacksPer[best]].sort((a, b) => b.v - a.v);
+    const total = rowsAll.reduce((s, r) => s + r.v, 0);
+    ttEl.textContent = '';
+    const dt = document.createElement('div'); dt.className = 'tt-date';
+    dt.textContent = fmtDate(out[best].t, gran) + (gran === 'day' ? ', ' + out[best].t.getFullYear() : '');
+    ttEl.appendChild(dt);
+    const tbl = document.createElement('table');
+    for (const s of rowsAll.slice(0, 10)) {
+      if (s.v <= 0) continue;
+      const tr = document.createElement('tr');
+      const n = document.createElement('td'); n.className = 'n';
+      const key = document.createElement('span'); key.className = 'key';
+      key.style.background = s.n === 'Other' ? 'var(--other)' : colorFn(s.n);
+      n.append(key, document.createTextNode(s.n));
+      const v = document.createElement('td'); v.className = 'v';
+      v.textContent = fmtVFull(s.v);
+      tr.append(n, v); tbl.appendChild(tr);
+    }
+    const tr = document.createElement('tr'); tr.className = 'total';
+    const n = document.createElement('td'); n.className = 'n'; n.textContent = 'Total';
+    const v = document.createElement('td'); v.className = 'v'; v.textContent = fmtVFull(total);
+    tr.append(n, v); tbl.appendChild(tr);
+    ttEl.appendChild(tbl);
+    ttEl.style.display = 'block';
+    const wr = wrap.getBoundingClientRect();
+    let lx = ev.clientX - wr.left + 16;
+    if (lx + ttEl.offsetWidth > wr.width - 8) lx = ev.clientX - wr.left - ttEl.offsetWidth - 16;
+    ttEl.style.left = lx + 'px';
+    ttEl.style.top = Math.min(ev.clientY - wr.top + 12, wr.height - ttEl.offsetHeight - 6) + 'px';
+  };
+  svg.onpointerleave = () => { ttEl.style.display = 'none'; cross.setAttribute('visibility', 'hidden'); };
+}
+
+/* ---------------- legends ----------------
+   Chips are hover highlighters, not filter controls: hovering one dims every
+   other series in the chart above it. Filtering lives only in the top bar. */
+function highlightSeries(svg, name) {
+  svg.querySelectorAll('[data-s]').forEach(m => {
+    m.style.opacity = (name == null || m.getAttribute('data-s') === name) ? '' : '0.12';
+  });
+}
+function renderChips(rootId, names, colorFn, otherTitle, svgId) {
+  const lg = document.getElementById(rootId);
+  lg.textContent = '';
+  const svg = document.getElementById(svgId);
+  for (const n of names) {
+    const chip = document.createElement('button');
+    chip.className = 'chip';
+    chip.style.cursor = 'default';
+    const sw = document.createElement('span'); sw.className = 'sw';
+    sw.style.background = n === 'Other' ? 'var(--other)' : colorFn(n);
+    chip.append(sw, document.createTextNode(n));
+    if (n === 'Other') chip.title = otherTitle || '';
+    chip.onpointerenter = () => highlightSeries(svg, n);
+    chip.onpointerleave = () => highlightSeries(svg, null);
+    lg.appendChild(chip);
+  }
+}
+
+/* ---------------- donut + ranked bars (share cards) ---------------- */
+function drawDonut(svg, cx, cy, R, data, fmtV, centerLbl) {
+  svg.textContent = '';
+  const total = data.reduce((s, d) => s + d.v, 0) || 1;
+  let a0 = -Math.PI / 2;
+  const r0 = R * .62;
+  for (const d of data) {
+    const a1 = a0 + d.v / total * 2 * Math.PI;
+    const large = a1 - a0 > Math.PI ? 1 : 0;
+    const p = (r, a) => [cx + r * Math.cos(a), cy + r * Math.sin(a)];
+    const [x0o, y0o] = p(R, a0), [x1o, y1o] = p(R, a1), [x1i, y1i] = p(r0, a1), [x0i, y0i] = p(r0, a0);
+    const mid = (a0 + a1) / 2;
+    el('path', {
+      d: `M${x0o} ${y0o}A${R} ${R} 0 ${large} 1 ${x1o} ${y1o}L${x1i} ${y1i}A${r0} ${r0} 0 ${large} 0 ${x0i} ${y0i}Z`,
+      fill: d.color, stroke: 'var(--surface-1)', 'stroke-width': 2,
+      'data-n': d.n,
+      'data-dx': (Math.cos(mid) * 6).toFixed(2), 'data-dy': (Math.sin(mid) * 6).toFixed(2),
+    }, svg);
+    a0 = a1;
+  }
+  const t1 = el('text', { x: cx, y: cy - 2, 'text-anchor': 'middle', 'font-size': 21, 'font-weight': 650, fill: 'var(--ink-1)' }, svg);
+  t1.textContent = fmtV(total);
+  const t2 = el('text', { x: cx, y: cy + 16, 'text-anchor': 'middle', 'font-size': 11, fill: 'var(--ink-3)' }, svg);
+  t2.textContent = centerLbl;
+}
+function drawRankedBars(svg, rows, fmtV) {
+  // rows: [{n, v, color}] already sorted desc; last row may be Other
+  svg.textContent = '';
+  const W = svg.clientWidth || 600;
+  const lh = 27, H = rows.length * lh + 4;
+  svg.setAttribute('height', H);
+  svg.setAttribute('viewBox', `0 0 ${W} ${H}`);
+  const total = rows.reduce((s, r) => s + r.v, 0) || 1;
+  const max = Math.max(...rows.map(r => r.v), 1e-9);
+  const lx = 108, vw = 118, bw = W - lx - vw;
+  rows.forEach((r, i) => {
+    const yy = i * lh + lh / 2 + 2;
+    const g = el('g', { 'data-n': r.n }, svg);
+    const t = el('text', { x: lx - 10, y: yy + 4, 'text-anchor': 'end', 'font-size': 12, fill: 'var(--ink-2)' }, g);
+    t.textContent = r.n;
+    const w = Math.max(2, r.v / max * bw);
+    el('path', { d: roundEndBarPath(lx, yy - 6, w, 12, Math.min(4, w / 2)), fill: r.color }, g);
+    const tv = el('text', { x: lx + w + 8, y: yy + 4, 'font-size': 12, 'font-weight': 600, fill: 'var(--ink-2)' }, g);
+    tv.textContent = fmtV(r.v);
+    const tp = el('text', { x: W - 2, y: yy + 4, 'text-anchor': 'end', 'font-size': 11.5, fill: 'var(--ink-3)' }, g);
+    tp.textContent = (r.v / total * 100).toFixed(1) + '%';
+    // full-row transparent hit target, larger than the mark
+    el('rect', { x: 0, y: i * lh, width: W, height: lh, fill: 'transparent' }, g);
+  });
+}
+
+/* linked hover between a share card's donut and its ranked bars */
+function linkShare(donutSvg, barsSvg) {
+  const segs = [...donutSvg.querySelectorAll('path[data-n]')];
+  const rowGs = [...barsSvg.querySelectorAll('g[data-n]')];
+  const set = name => {
+    const inDonut = name != null && segs.some(s => s.dataset.n === name);
+    segs.forEach(s => {
+      const isHit = s.dataset.n === name;
+      s.style.opacity = (name == null || !inDonut || isHit) ? '' : '0.3';
+      s.setAttribute('transform', (isHit ? `translate(${s.dataset.dx} ${s.dataset.dy})` : ''));
+    });
+    rowGs.forEach(g => { g.style.opacity = (name == null || g.dataset.n === name) ? '' : '0.3'; });
+  };
+  const wire = elm => {
+    elm.addEventListener('pointerenter', () => set(elm.dataset.n));
+    elm.addEventListener('pointerleave', () => set(null));
+  };
+  segs.forEach(wire); rowGs.forEach(wire);
+}
+
+/* ---------------- provider section ---------------- */
+function renderProvTrend() {
+  const db = rangeDays();
+  const { out, gran } = provBuckets(db);
+  document.getElementById('granHint').textContent =
+    out.length + (gran === 'month' ? ' monthly' : ' daily') + ' buckets';
+  const m = state.metric;
+  document.getElementById('provTrendTitle').textContent =
+    (m === 'volume' ? 'Volume' : m === 'revenue' ? 'Estimated revenue' : 'Transactions') + ' by provider';
+  document.getElementById('provShareMetricLbl').textContent =
+    m === 'txs' ? 'transactions' : m === 'revenue' ? 'est. revenue' : 'volume';
+
+  const present = PROVIDERS.filter(p => p.active && typeMatch(p) && state.enabled.has(p.name)).map(p => p.name);
+  const fold = foldSeries(present, SLOT);
+  const othersTitle = fold.others.join(', ');
+  if (!state.provShowOther) fold.others = []; // card-local: hide the Other series here only
+  drawTimeSeries(document.getElementById('provTrend'), document.getElementById('provTT'), {
+    out, gran, chartType: state.provChart,
+    valueOf: (n, b) => b.vals[n] ? metricOf(b.vals[n], m) : 0,
+    colorFn: colorOf,
+    fmtV: v => fmtMetric(v, m), fmtVFull: v => fmtMetricFull(v, m),
+    seriesFold: fold,
+  });
+  const names = fold.others.length ? [...fold.tops, 'Other'] : fold.tops;
+  renderChips('provLegend', names, colorOf, othersTitle, 'provTrend');
+}
+function renderProvShare() {
+  const db = rangeDays();
+  const m = state.metric;
+  const rows = providerRows(db).filter(r => state.enabled.has(r.p.name))
+    .map(r => ({ n: r.p.name, v: metricOf({ usd: r.usd, rev: r.rev, txs: r.txs }, m) }))
+    .sort((a, b) => b.v - a.v);
+  // parity with the trend chart: the same top 8 series + Other, in ring AND bars
+  const shown = rows.slice(0, 8).map(r => ({ ...r, color: colorOf(r.n) }));
+  const rest = rows.slice(8).reduce((s, r) => s + r.v, 0);
+  if (state.provShareOther && rest > 0) shown.push({ n: 'Other', v: rest, color: 'var(--other)' });
+  drawDonut(document.getElementById('provDonut'), 100, 100, 82, shown,
+    v => fmtMetric(v, m), m === 'txs' ? 'total txs' : m === 'revenue' ? 'total est. rev' : 'total volume');
+  drawRankedBars(document.getElementById('provBars'), shown, v => fmtMetric(v, m));
+  linkShare(document.getElementById('provDonut'), document.getElementById('provBars'));
+}
+const trendDeltaOf = pts => {
+  const mean = pts.reduce((a, b) => a + b, 0) / pts.length;
+  return mean ? (pts[pts.length - 1] - pts[0]) / mean : 0;
+};
+function renderTable() {
+  const db = rangeDays();
+  const rowsAll = providerRows(db).filter(r => state.enabled.has(r.p.name));
+  const totalUsd = rowsAll.reduce((s, r) => s + r.usd, 0) || 1;
+  let list = rowsAll.map(r => ({ ...r, share: r.usd / totalUsd, avg: r.txs ? r.usd / r.txs : 0 }));
+  list.forEach(r => {
+    const dayVals = [];
+    for (let d = db.from; d >= db.to; d--) {
+      const b = daily[r.p.i][DAYS - 1 - d];
+      dayVals.push(b ? bucketSlice(b).vol : 0);
+    }
+    r.trendPts = trendPoints(dayVals, 12);
+    r.trend = trendDeltaOf(r.trendPts);
+  });
+  const inactive = PROVIDERS.filter(p => !p.active);
+  const key = { name: r => r.p.name.toLowerCase(), vol: r => r.usd, rev: r => r.rev, txs: r => r.txs, avg: r => r.avg, share: r => r.share, trend: r => r.trend };
+  list.sort((a, b) => {
+    const ka = key[state.sortBy](a), kb = key[state.sortBy](b);
+    return (ka < kb ? -1 : ka > kb ? 1 : 0) * state.sortDir;
+  });
+  const tbl = document.getElementById('provTable');
+  tbl.textContent = '';
+  const thr = document.createElement('tr');
+  const cols = [['name','Provider'],['vol','Volume'],['share','Share'],['rev','Est. revenue'],['txs','Txs'],['avg','Avg tx'],['trend','Trend']];
+  for (const [id, label] of cols) {
+    const th = document.createElement('th');
+    th.textContent = label + (state.sortBy === id ? (state.sortDir < 0 ? ' ▼' : ' ▲') : '');
+    th.onclick = () => {
+      if (state.sortBy === id) state.sortDir *= -1; else { state.sortBy = id; state.sortDir = id === 'name' ? 1 : -1; }
+      renderTable();
+    };
+    thr.appendChild(th);
+  }
+  tbl.appendChild(thr);
+
+  const db2 = db;
+  const mk = (r, dimmed) => {
+    const tr = document.createElement('tr');
+    if (dimmed) tr.className = 'dim';
+    const td0 = document.createElement('td');
+    const nm = document.createElement('span'); nm.className = 'pname';
+    const sw = document.createElement('span'); sw.className = 'sw';
+    sw.style.background = dimmed ? 'var(--grid)' : colorOf(r.p.name);
+    nm.append(sw, document.createTextNode(r.p.name));
+    td0.appendChild(nm);
+    const badge = document.createElement('span'); badge.className = 'muted';
+    badge.textContent = '  ' + (r.p.type === 'fiat' ? 'fiat' : 'swap');
+    badge.style.fontSize = '11px';
+    td0.appendChild(badge);
+    tr.appendChild(td0);
+    let td = document.createElement('td'); td.textContent = fmtMoney(r.usd); td.title = fmtMoneyFull(r.usd); tr.appendChild(td);
+    td = document.createElement('td');
+    const sc = document.createElement('span'); sc.className = 'share-cell';
+    const sb = document.createElement('span'); sb.className = 'share-bar';
+    const fi = document.createElement('i'); fi.style.width = Math.min(100, r.share * 250) + '%';
+    sb.appendChild(fi);
+    const pt = document.createElement('span'); pt.textContent = (r.share * 100).toFixed(1) + '%';
+    sc.append(sb, pt); td.appendChild(sc); tr.appendChild(td);
+    td = document.createElement('td'); td.textContent = fmtMoney(r.rev); tr.appendChild(td);
+    td = document.createElement('td'); td.textContent = Math.round(r.txs).toLocaleString('en-US'); tr.appendChild(td);
+    td = document.createElement('td'); td.textContent = fmtMoney(r.avg); tr.appendChild(td);
+    td = document.createElement('td');
+    if (!dimmed && r.trendPts) td.appendChild(sparkline(r.trendPts, 90, 24, colorOf(r.p.name)));
+    tr.appendChild(td);
+    return tr;
+  };
+  for (const r of list) tbl.appendChild(mk(r, false));
+  if (state.showInactive) {
+    for (const p of inactive) tbl.appendChild(mk({ p, usd: 0, rev: 0, txs: 0, avg: 0, share: 0 }, true));
+  }
+  document.getElementById('provCount').textContent =
+    list.length + ' shown · ' + inactive.length + ' inactive hidden' + (state.showInactive ? ' (shown)' : '');
+}
+
+/* ---------------- pairs section ---------------- */
+function renderPairTrend() {
+  const db = rangeDays();
+  const { out, gran } = pairBuckets(db);
+  const present = [...new Set(out.flatMap(b => Object.keys(b.vals)))]
+    .sort((a, b) => (PAIR_RANKED.indexOf(a) + 1 || 99) - (PAIR_RANKED.indexOf(b) + 1 || 99));
+  const fold = foldSeries(present, PAIRSLOT);
+  const othersTitle = fold.others.join(', ');
+  if (!state.pairShowOther) fold.others = []; // card-local: hide the Other series here only
+  drawTimeSeries(document.getElementById('pairTrend'), document.getElementById('pairTT'), {
+    out, gran, chartType: state.pairChart,
+    valueOf: (n, b) => b.vals[n] || 0,
+    colorFn: colorOfPair,
+    fmtV: fmtMoney, fmtVFull: fmtMoneyFull,
+    seriesFold: fold,
+  });
+  const names = fold.others.length ? [...fold.tops, 'Other'] : fold.tops;
+  renderChips('pairLegend', names, colorOfPair, othersTitle, 'pairTrend');
+}
+function renderPairShare() {
+  const db = rangeDays();
+  const agg = pairAgg(db);
+  const rows = Object.entries(agg).map(([n, v]) => ({ n, v })).sort((a, b) => b.v - a.v);
+  // parity with the trend chart: the same top 8 series + Other, in ring AND bars
+  const shown = rows.slice(0, 8).map(r => ({ ...r, color: colorOfPair(r.n) }));
+  const rest = rows.slice(8).reduce((s, r) => s + r.v, 0);
+  if (state.pairShareOther && rest > 0) shown.push({ n: 'Other', v: rest, color: 'var(--other)' });
+  drawDonut(document.getElementById('pairDonut'), 100, 100, 82, shown, fmtMoney, 'total volume');
+  drawRankedBars(document.getElementById('pairBars'), shown, fmtMoney);
+  linkShare(document.getElementById('pairDonut'), document.getElementById('pairBars'));
+}
+
+/* ---------------- pair detail table (paginated) ---------------- */
+function pairDetailRows(daysBack) {
+  const { from, to } = daysBack;
+  const agg = {};
+  for (const p of PROVIDERS.filter(p => p.active && typeMatch(p) && state.enabled.has(p.name))) {
+    for (let d = from; d >= to; d--) {
+      const b = daily[p.i][DAYS - 1 - d]; if (!b) continue;
+      for (const k in b.pairs) {
+        if (!state.enabledPairs.has(k)) continue;
+        const a = agg[k] || (agg[k] = { vol: 0, rev: 0, provs: new Set() });
+        a.vol += b.pairs[k]; a.rev += b.pairs[k] * p.rr;
+        if (b.pairs[k] > 0) a.provs.add(p.name);
+      }
+    }
+  }
+  return Object.entries(agg).map(([n, a]) => ({ n, vol: a.vol, rev: a.rev, provs: a.provs.size }));
+}
+function renderPairTable() {
+  const db = rangeDays();
+  const rows = pairDetailRows(db);
+  const total = rows.reduce((s, r) => s + r.vol, 0) || 1;
+  const { out } = pairBuckets(db); // per-bucket per-pair volumes for sparklines/trend
+  rows.forEach(r => {
+    r.share = r.vol / total;
+    r.trendPts = trendPoints(out.map(b => b.vals[r.n] || 0), 12);
+    r.trend = trendDeltaOf(r.trendPts);
+  });
+  const key = { name: r => r.n.toLowerCase(), vol: r => r.vol, share: r => r.share, rev: r => r.rev, provs: r => r.provs, trend: r => r.trend };
+  rows.sort((a, b) => {
+    const ka = key[state.pairSortBy](a), kb = key[state.pairSortBy](b);
+    return (ka < kb ? -1 : ka > kb ? 1 : 0) * state.pairSortDir;
+  });
+  const ps = state.pairPageSize;
+  const pages = Math.max(1, Math.ceil(rows.length / ps));
+  state.pairPage = Math.min(state.pairPage, pages - 1);
+  const pageRows = rows.slice(state.pairPage * ps, (state.pairPage + 1) * ps);
+
+  const tbl = document.getElementById('pairTable');
+  tbl.textContent = '';
+  const thr = document.createElement('tr');
+  const cols = [['name','Pair'],['vol','Volume'],['share','Share'],['rev','Est. revenue'],['provs','Providers'],['trend','Trend']];
+  for (const [id, label] of cols) {
+    const th = document.createElement('th');
+    th.textContent = label + (state.pairSortBy === id ? (state.pairSortDir < 0 ? ' ▼' : ' ▲') : '');
+    th.onclick = () => {
+      if (state.pairSortBy === id) state.pairSortDir *= -1;
+      else { state.pairSortBy = id; state.pairSortDir = id === 'name' ? 1 : -1; }
+      state.pairPage = 0;
+      renderPairTable();
+    };
+    thr.appendChild(th);
+  }
+  tbl.appendChild(thr);
+  for (const r of pageRows) {
+    const tr = document.createElement('tr');
+    const td0 = document.createElement('td');
+    const nm = document.createElement('span'); nm.className = 'pname';
+    const sw = document.createElement('span'); sw.className = 'sw';
+    sw.style.background = colorOfPair(r.n);
+    nm.append(sw, document.createTextNode(r.n));
+    td0.appendChild(nm);
+    tr.appendChild(td0);
+    let td = document.createElement('td'); td.textContent = fmtMoney(r.vol); td.title = fmtMoneyFull(r.vol); tr.appendChild(td);
+    td = document.createElement('td');
+    const sc = document.createElement('span'); sc.className = 'share-cell';
+    const sb = document.createElement('span'); sb.className = 'share-bar';
+    const fi = document.createElement('i'); fi.style.width = Math.min(100, r.share * 250) + '%';
+    sb.appendChild(fi);
+    const pt = document.createElement('span'); pt.textContent = (r.share * 100).toFixed(1) + '%';
+    sc.append(sb, pt); td.appendChild(sc); tr.appendChild(td);
+    td = document.createElement('td'); td.textContent = fmtMoney(r.rev); tr.appendChild(td);
+    td = document.createElement('td'); td.textContent = r.provs; tr.appendChild(td);
+    td = document.createElement('td');
+    td.appendChild(sparkline(r.trendPts, 90, 24, colorOfPair(r.n)));
+    tr.appendChild(td);
+    tbl.appendChild(tr);
+  }
+
+  document.getElementById('pairCount').textContent = rows.length + ' pairs';
+  const pager = document.getElementById('pairPager');
+  pager.textContent = '';
+  const info = document.createElement('span');
+  const lo = rows.length ? state.pairPage * ps + 1 : 0;
+  info.textContent = lo + '–' + Math.min(rows.length, (state.pairPage + 1) * ps) + ' of ' + rows.length;
+  const prev = document.createElement('button'); prev.className = 'btn'; prev.textContent = '‹ Prev';
+  const next = document.createElement('button'); next.className = 'btn'; next.textContent = 'Next ›';
+  prev.disabled = state.pairPage === 0;
+  next.disabled = state.pairPage >= pages - 1;
+  prev.onclick = () => { if (state.pairPage > 0) { state.pairPage--; renderPairTable(); } };
+  next.onclick = () => { if (state.pairPage < pages - 1) { state.pairPage++; renderPairTable(); } };
+  pager.append(info, prev, next);
+}
+
+/* ---------------- filter UI ---------------- */
+function renderRangePanel() {
+  const panel = document.getElementById('rangePanel');
+  panel.textContent = '';
+  for (const p of PRESETS) {
+    const b = document.createElement('button'); b.className = 'dd-row';
+    const c = document.createElement('span'); c.className = 'check';
+    c.textContent = (!state.custom && state.preset === p.id) ? '✓' : '';
+    b.append(c, document.createTextNode(p.label));
+    b.onclick = () => {
+      state.preset = p.id; state.custom = null;
+      document.getElementById('rangeBtn').textContent = '▦ ' + p.label + ' ▾';
+      closeDD(); renderAll(); renderRangePanel();
+    };
+    panel.appendChild(b);
+  }
+  const foot = document.createElement('div'); foot.className = 'dd-foot';
+  const l1 = document.createElement('label'); l1.textContent = 'Custom range';
+  const i1 = document.createElement('input'); i1.type = 'date'; i1.value = '2026-06-01';
+  const i2 = document.createElement('input'); i2.type = 'date'; i2.value = '2026-07-30'; i2.style.marginTop = '4px';
+  const go = document.createElement('button'); go.className = 'btn'; go.textContent = 'Apply';
+  go.onclick = () => {
+    const a = new Date(i1.value), b = new Date(i2.value);
+    if (isNaN(a) || isNaN(b) || a > b) return;
+    state.custom = [a, b];
+    document.getElementById('rangeBtn').textContent = '▦ ' + i1.value + ' → ' + i2.value + ' ▾';
+    closeDD(); renderAll(); renderRangePanel();
+  };
+  foot.append(l1, i1, i2, go);
+  panel.appendChild(foot);
+}
+function renderProvList() {
+  const list = document.getElementById('provList');
+  list.textContent = '';
+  const q = state.provSearch.toLowerCase();
+  for (const p of PROVIDERS.filter(p => p.active)) {
+    if (q && !p.name.toLowerCase().includes(q)) continue;
+    const b = document.createElement('button'); b.className = 'dd-row';
+    const c = document.createElement('span'); c.className = 'check';
+    c.textContent = state.enabled.has(p.name) ? '✓' : '';
+    const sw = document.createElement('span'); sw.className = 'sw';
+    sw.style.background = colorOf(p.name);
+    b.append(c, sw, document.createTextNode(p.name));
+    const tag = document.createElement('span'); tag.className = 'muted'; tag.style.marginLeft = 'auto'; tag.style.fontSize = '11px';
+    tag.textContent = p.type;
+    b.appendChild(tag);
+    b.onclick = () => {
+      state.enabled.has(p.name) ? state.enabled.delete(p.name) : state.enabled.add(p.name);
+      updateProvBtn(); renderProvList(); renderAll();
+    };
+    list.appendChild(b);
+  }
+}
+function renderPairList() {
+  const list = document.getElementById('pairList');
+  list.textContent = '';
+  const q = state.pairSearch.toLowerCase();
+  for (const n of PAIR_RANKED) {
+    if (q && !n.toLowerCase().includes(q)) continue;
+    const b = document.createElement('button'); b.className = 'dd-row';
+    const c = document.createElement('span'); c.className = 'check';
+    c.textContent = state.enabledPairs.has(n) ? '✓' : '';
+    const sw = document.createElement('span'); sw.className = 'sw';
+    sw.style.background = colorOfPair(n);
+    b.append(c, sw, document.createTextNode(n));
+    b.onclick = () => {
+      state.enabledPairs.has(n) ? state.enabledPairs.delete(n) : state.enabledPairs.add(n);
+      updatePairBtn(); renderPairList(); renderAll();
+    };
+    list.appendChild(b);
+  }
+}
+function updateProvBtn() {
+  const total = PROVIDERS.filter(p => p.active).length;
+  const n = state.enabled.size;
+  document.getElementById('provBtn').textContent =
+    (n === total ? 'All providers' : n + '/' + total + ' providers') + ' ▾';
+}
+function updatePairBtn() {
+  const total = PAIR_RANKED.length;
+  const n = state.enabledPairs.size;
+  document.getElementById('pairBtn').textContent =
+    (n === total ? 'All pairs' : n + '/' + total + ' pairs') + ' ▾';
+}
+function closeDD() { document.querySelectorAll('.dd.open').forEach(d => d.classList.remove('open')); }
+
+/* ---------------- wiring ---------------- */
+function seg(id, onPick) {
+  const root = document.getElementById(id);
+  root.querySelectorAll('button').forEach(b => b.onclick = () => {
+    root.querySelectorAll('button').forEach(x => x.classList.toggle('on', x === b));
+    onPick(b.dataset.v);
+  });
+}
+seg('metricSeg', v => { state.metric = v; renderAll(); });
+seg('provChartSeg', v => { state.provChart = v; renderProvTrend(); });
+seg('pairChartSeg', v => { state.pairChart = v; renderPairTrend(); });
+seg('typeSeg', v => { state.type = v; renderAll(); });
+function toggleDD(ddId) {
+  return e => {
+    e.stopPropagation();
+    const d = document.getElementById(ddId);
+    const was = d.classList.contains('open');
+    closeDD(); if (!was) d.classList.add('open');
+  };
+}
+document.getElementById('rangeBtn').onclick = toggleDD('rangeDD');
+document.getElementById('provBtn').onclick = toggleDD('provDD');
+document.getElementById('pairBtn').onclick = toggleDD('pairDD');
+document.querySelectorAll('.dd-panel').forEach(p => p.onclick = e => e.stopPropagation());
+document.addEventListener('click', closeDD);
+document.getElementById('provSearch').oninput = e => { state.provSearch = e.target.value; renderProvList(); };
+document.getElementById('pairSearch').oninput = e => { state.pairSearch = e.target.value; renderPairList(); };
+document.getElementById('provAll').onclick = () => { PROVIDERS.filter(p => p.active).forEach(p => state.enabled.add(p.name)); updateProvBtn(); renderProvList(); renderAll(); };
+document.getElementById('provNone').onclick = () => { state.enabled.clear(); updateProvBtn(); renderProvList(); renderAll(); };
+document.getElementById('pairAll').onclick = () => { PAIR_RANKED.forEach(n => state.enabledPairs.add(n)); updatePairBtn(); renderPairList(); renderAll(); };
+document.getElementById('pairNone').onclick = () => { state.enabledPairs.clear(); updatePairBtn(); renderPairList(); renderAll(); };
+document.getElementById('showInactive').onchange = e => { state.showInactive = e.target.checked; renderTable(); };
+document.getElementById('provOther').onchange = e => { state.provShowOther = e.target.checked; renderProvTrend(); };
+document.getElementById('pairOther').onchange = e => { state.pairShowOther = e.target.checked; renderPairTrend(); };
+document.getElementById('provShareOtherCb').onchange = e => { state.provShareOther = e.target.checked; renderProvShare(); };
+document.getElementById('pairShareOtherCb').onchange = e => { state.pairShareOther = e.target.checked; renderPairShare(); };
+document.getElementById('pairPageSize').onchange = e => { state.pairPageSize = +e.target.value; state.pairPage = 0; renderPairTable(); };
+document.getElementById('themeBtn').onclick = () => {
+  const r = document.documentElement;
+  const dark = matchMedia('(prefers-color-scheme: dark)').matches;
+  const cur = r.dataset.theme || (dark ? 'dark' : 'light');
+  r.dataset.theme = cur === 'dark' ? 'light' : 'dark';
+  renderAll();
+};
+
+function renderProviders() { renderProvTrend(); renderProvShare(); renderTable(); }
+function renderPairs() { renderPairTrend(); renderPairShare(); renderPairTable(); }
+function renderAll() { computeSlots(); renderSummary(); renderProviders(); renderPairs(); }
+
+/* ---------------- boot / auth ---------------- */
+const API_KEY_COOKIE = 'apiKey';
+let rsz;
+
+function renderDashboard() {
+  // seed the filter selections from whatever loaded (all on by default)
+  state.enabled = new Set(PROVIDERS.filter(p => p.active).map(p => p.name));
+  state.enabledPairs = new Set(ALL_PAIR_NAMES);
+  const activeCount = PROVIDERS.filter(p => p.active).length;
+  document.getElementById('headerSub').textContent =
+    activeCount + ' active provider' + (activeCount === 1 ? '' : 's') + ' · live /v1 data';
+  computeSlots(); // assign colors before the dropdown swatches render
+  renderRangePanel();
+  renderProvList(); renderPairList();
+  updateProvBtn(); updatePairBtn();
+  renderAll();
+}
+
+function showGate(message) {
+  document.getElementById('boot').classList.add('hide');
+  document.getElementById('app').classList.remove('ready');
+  document.getElementById('gateErr').textContent = message || '';
+  document.getElementById('gate').classList.add('show');
+  const input = document.getElementById('keyInput');
+  input.value = '';
+  input.focus();
+}
+
+async function enter(apiKey) {
+  document.getElementById('gate').classList.remove('show');
+  const boot = document.getElementById('boot');
+  boot.classList.remove('hide');
+  document.getElementById('bootMsg').textContent = 'Loading reports…';
+  try {
+    await apiGetAppId(apiKey);        // validates the key (redirect on failure)
+    setCookie(API_KEY_COOKIE, apiKey);
+    await loadData(apiKey);
+    boot.classList.add('hide');
+    document.getElementById('app').classList.add('ready');
+    renderDashboard();
+    // charts size to their container, so a first post-display render is needed
+    renderAll();
+  } catch (err) {
+    if (err instanceof AuthError) {
+      clearCookie(API_KEY_COOKIE);
+      showGate('That API key was not recognized.');
+    } else {
+      showGate('Could not load reports: ' + (err && err.message ? err.message : 'unknown error'));
+    }
+  }
+}
+
+function submitKey() {
+  const key = document.getElementById('keyInput').value.trim();
+  if (key === '') { document.getElementById('gateErr').textContent = 'Enter an API key.'; return; }
+  enter(key);
+}
+document.getElementById('keySubmit').onclick = submitKey;
+document.getElementById('keyInput').addEventListener('keydown', e => { if (e.key === 'Enter') submitKey(); });
+document.getElementById('signOut').onclick = () => { clearCookie(API_KEY_COOKIE); showGate(''); };
+
+addEventListener('resize', () => {
+  if (!document.getElementById('app').classList.contains('ready')) return;
+  clearTimeout(rsz); rsz = setTimeout(renderAll, 150);
+});
+
+// A ?apiKey= query param seeds the key (handy for links); otherwise use the cookie.
+const params = new URLSearchParams(location.search);
+const initialKey = params.get('apiKey') || getCookie(API_KEY_COOKIE);
+if (initialKey != null && initialKey !== '') enter(initialKey);
+else showGate('');
+</script>

--- a/src/indexApi.ts
+++ b/src/indexApi.ts
@@ -9,6 +9,7 @@ import { checkTxsRouter } from './routes/v1/checkTxs'
 import { getAppIdRouter } from './routes/v1/getAppId'
 import { getPluginIdsRouter } from './routes/v1/getPluginIds'
 import { getTxInfoRouter } from './routes/v1/getTxInfo'
+import { getConfigRouter } from './routes/v2/getConfig'
 import { HttpError } from './util/httpErrors'
 
 export const nanoDb = nano(config.couchDbFullpath)
@@ -29,6 +30,11 @@ async function main(): Promise<void> {
   app.use('/v1/getAppId/', getAppIdRouter)
   app.use('/v1/getPluginIds/', getPluginIdsRouter)
   app.use('/v1/getTxInfo/', getTxInfoRouter)
+
+  // v2 dashboard config (isolated; v1 routes untouched). The static handler
+  // above serves the built /v2/ bundle from dist; this API path falls through
+  // it because no matching file exists in dist.
+  app.use('/v2/config/', getConfigRouter)
 
   // Error router
   app.use(function(err, _req, res, _next) {

--- a/src/partners/revolut.ts
+++ b/src/partners/revolut.ts
@@ -84,7 +84,15 @@ const asRevolutOrder = asObject({
   status: asRevolutStatus,
   payment: asMaybe(asString),
   wallet: asMaybe(asString),
-  transaction_hash: asMaybe(asString)
+  transaction_hash: asMaybe(asString),
+  // Edge's actual cut, pre-converted by Revolut to the partner's settlement
+  // currency (USD across the full live history). asMaybe throughout: FAILED
+  // rows commonly omit the whole block.
+  fees_partner_currency: asMaybe(
+    asObject({
+      partner_fee: asMaybe(asRevolutAmount)
+    })
+  )
 })
 type RevolutOrder = ReturnType<typeof asRevolutOrder>
 
@@ -333,6 +341,17 @@ export function processRevolutTx(
   const { isoDate, timestamp } = smartIsoDateFromTimestamp(tx.created_at)
   const payout = resolveRevolutAsset(tx.crypto.currencyId)
 
+  // Actual revenue, only when Revolut reports it in USD and the order settled:
+  // an unsettled attempt's fee is not revenue, and a non-USD settlement
+  // currency would need a conversion this plugin cannot do honestly.
+  const partnerFee = tx.fees_partner_currency?.partner_fee
+  const revenueUsd =
+    tx.status === 'COMPLETED' &&
+    partnerFee != null &&
+    partnerFee.currency === 'USD'
+      ? partnerFee.amount
+      : undefined
+
   // Revolut Ramp only reports on-ramp orders, so fiat is always the deposit
   // side and crypto always the payout side. `wallet` is the user's receiving
   // address and `transaction_hash` the payout transaction.
@@ -360,6 +379,8 @@ export function processRevolutTx(
     timestamp,
     isoDate,
     usdValue: -1,
+    revenueUsd,
+    revenueSource: revenueUsd != null ? 'reported' : undefined,
     rawTx
   }
 }

--- a/src/routes/v1/getTxInfo.ts
+++ b/src/routes/v1/getTxInfo.ts
@@ -92,7 +92,10 @@ getTxInfoRouter.get('/', async function(req, res) {
 
   const rows = results.docs
     .map(doc => asMaybe(asDbTx)(doc))
-    .filter((item): item is DbTx => item != null)
+    // Narrow on the cleaner's own return type: DbTx's revenue keys are
+    // optional-key relaxed, so it is no longer a subtype of that return type
+    // and cannot serve as the predicate target.
+    .filter((item): item is NonNullable<typeof item> => item != null)
 
   const txs: TxInfo[] = rows.map(row => ({
     providerId: getProviderId(row),

--- a/src/routes/v2/getConfig.ts
+++ b/src/routes/v2/getConfig.ts
@@ -1,0 +1,111 @@
+import { asMap, asMaybe, asNumber, asObject, asOptional } from 'cleaners'
+import Router from 'express-promise-router'
+
+import { reportsApps } from '../../indexApi'
+
+/**
+ * Rev-share rates live on the app doc in `reports_apps`, as an optional
+ * `revShareRate` beside each partner's `apiKeys`. The rate is a property of the
+ * app-partner deal, so it is per app AND per partner, and it sits with the
+ * credentials that define the relationship: onboarding a partner is one doc
+ * edit, with no separate rates map to forget. The rates are commercial terms
+ * and this repo is public, so they are never committed or placed in
+ * config.json. A partner without one contributes 0 estimated revenue.
+ *
+ * Tolerant cleaner: only the fields this route consumes, and a malformed
+ * partner entry degrades to no rate rather than failing the whole request.
+ */
+const asAppRevShareRates = asObject({
+  partnerIds: asMap(asMaybe(asObject({ revShareRate: asOptional(asNumber) })))
+})
+
+const getRevShareRates = async (
+  apiKey: string
+): Promise<{ [partnerId: string]: number }> => {
+  // The app doc's _id IS the apiKey (same lookup validateApiKey uses), so a
+  // missing doc doubles as auth failure and is thrown to the caller.
+  const doc = await reportsApps.get(apiKey)
+  const { partnerIds } = asAppRevShareRates(doc)
+  const rates: { [partnerId: string]: number } = {}
+  for (const partnerId of Object.keys(partnerIds)) {
+    const rate = partnerIds[partnerId]?.revShareRate
+    if (rate != null) rates[partnerId] = rate
+  }
+  return rates
+}
+
+/**
+ * Static fiat/swap classification per pluginId, duplicated into v2 so the
+ * dashboard can offer its fiat-buy/sell vs swap filter. The reporting API does
+ * not expose exchange type. Derived from src/partners/* `exchangeType`, plus the
+ * newer ramp/swap plugins not yet in that registry. Unknown pluginIds default to
+ * 'swap' on the client.
+ */
+const providerTypes: { [pluginId: string]: 'fiat' | 'swap' } = {
+  // fiat (on/off ramp)
+  banxa: 'fiat',
+  bitaccess: 'fiat',
+  bitrefill: 'fiat',
+  bitsofgold: 'fiat',
+  bity: 'fiat',
+  ioniagiftcard: 'fiat',
+  ioniavisarewards: 'fiat',
+  kado: 'fiat',
+  libertyx: 'fiat',
+  moonpay: 'fiat',
+  paybis: 'fiat',
+  paytrie: 'fiat',
+  revolut: 'fiat',
+  safello: 'fiat',
+  simplex: 'fiat',
+  transak: 'fiat',
+  wyre: 'fiat',
+  xanpool: 'fiat',
+  // swap
+  bridgeless: 'swap',
+  changehero: 'swap',
+  changelly: 'swap',
+  changenow: 'swap',
+  coinswitch: 'swap',
+  exolix: 'swap',
+  faast: 'swap',
+  foxexchange: 'swap',
+  godex: 'swap',
+  letsexchange: 'swap',
+  lifi: 'swap',
+  maya: 'swap',
+  nym: 'swap',
+  rango: 'swap',
+  shapeshift: 'swap',
+  sideshift: 'swap',
+  swapter: 'swap',
+  swapuz: 'swap',
+  switchain: 'swap',
+  thorchain: 'swap',
+  totle: 'swap'
+}
+
+export const getConfigRouter = Router()
+
+getConfigRouter.get('/', async function(req, res) {
+  const apiKey = req.query.apiKey
+  if (typeof apiKey !== 'string' || apiKey === '') {
+    res.status(400).send(`Missing Request fields.`)
+    return
+  }
+
+  // Same auth as v1: the app doc keyed by apiKey. An unrecognized key 401s so
+  // the v2 client redirects to its key-entry screen instead of hanging.
+  let revShareRates: { [partnerId: string]: number }
+  try {
+    revShareRates = await getRevShareRates(apiKey)
+  } catch {
+    res.status(401).send(`Invalid API Key`)
+    return
+  }
+
+  res.json({
+    revShareRates,
+    providerTypes
+  })
+})

--- a/src/types.ts
+++ b/src/types.ts
@@ -148,6 +148,21 @@ export const asStandardTx = asObject({
   isoDate: asString,
   timestamp: asNumber,
   usdValue: asNumber,
+  /**
+   * Edge's actual revenue on this order in USD, when the partner's API reports
+   * it (e.g. Revolut's partner_fee, pre-converted to USD by Revolut). Stored at
+   * ingest as a fact about the order, never recomputed. Absent when the partner
+   * does not report one; the v2 dashboard then estimates revenue at read time
+   * as usdValue * the app doc's per-partner revShareRate, so a corrected rate
+   * fixes history immediately while reported figures stay immutable.
+   */
+  revenueUsd: asOptional(asNumber),
+  /**
+   * How revenueUsd was obtained. 'reported' is the only value written at
+   * ingest; 'estimated' exists so read-time consumers can tag derived figures
+   * without inventing a second vocabulary.
+   */
+  revenueSource: asOptional(asValue('reported', 'estimated')),
   rawTx: asUnknown
 })
 
@@ -203,6 +218,9 @@ const asCacheEntry = asObject({
   timestamp: asNumber,
   usdValue: asNumber,
   numTxs: asNumber,
+  // Sum of reported revenueUsd across the bucket's txs. Optional: cache docs
+  // written before this field existed lack it, and rebuilding fills it in.
+  revenueUsd: asOptional(asNumber),
   currencyCodes: asObject(asNumber),
   currencyPairs: asObject(asNumber)
 })
@@ -215,6 +233,7 @@ export const asBucket = asObject({
   start: asNumber,
   usdValue: asNumber,
   numTxs: asNumber,
+  revenueUsd: asOptional(asNumber),
   isoDate: asString,
   currencyCodes: asObject(asNumber),
   currencyPairs: asObject(asNumber)
@@ -274,8 +293,31 @@ export type AnalyticsResult = ReturnType<typeof asAnalyticsResult>
 
 export type CurrencyCodeMappings = ReturnType<typeof asCurrencyCodeMappings>
 export type DbCurrencyCodeMappings = ReturnType<typeof asDbCurrencyCodeMappings>
-export type DbTx = ReturnType<typeof asDbTx>
-export type StandardTx = ReturnType<typeof asStandardTx>
+// Same optional-key relaxation as StandardTx (asDbTx spreads its shape).
+export type DbTx = Omit<
+  ReturnType<typeof asDbTx>,
+  'revenueUsd' | 'revenueSource'
+> & {
+  revenueUsd?: number
+  revenueSource?: string
+}
+/**
+ * `revenueUsd`/`revenueSource` are truly optional KEYS, not just
+ * possibly-undefined values: only partners whose APIs report an actual fee set
+ * them, and requiring every other plugin to spell out two explicit undefineds
+ * would churn the whole partner directory for no information. The cleaner
+ * still validates both fields when present.
+ */
+export type StandardTx = Omit<
+  ReturnType<typeof asStandardTx>,
+  'revenueUsd' | 'revenueSource'
+> & {
+  revenueUsd?: number
+  // Widened to string at the type level because asObject's shape inference
+  // widens asValue literals anyway; the cleaner still enforces
+  // 'reported' | 'estimated' at runtime.
+  revenueSource?: string
+}
 export type PluginParams = ReturnType<typeof asPluginParams> & {
   log: ScopedLog
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -179,7 +179,15 @@ export const asStandardPluginParams = asObject({
 
 const asPartnerInfo = asObject({
   pluginId: asOptional(asString),
-  apiKeys: asMap(asString)
+  apiKeys: asMap(asString),
+  /**
+   * Revenue-share rate for this app-partner relationship (fraction of volume),
+   * used by the v2 dashboard to estimate revenue when the partner's API does
+   * not report actual fees. Lives here, beside the credentials that define the
+   * relationship, because the rate is a property of the deal: per app AND per
+   * partner. Never committed to source; this repo is public.
+   */
+  revShareRate: asOptional(asNumber)
 })
 
 export const asApp = asObject({

--- a/test/revolut.test.ts
+++ b/test/revolut.test.ts
@@ -254,6 +254,53 @@ describe('processRevolutTx', function() {
     expect(standardTx.payoutTokenId).to.equal(undefined)
   })
 
+  it('stores the partner-reported USD fee as revenue on a settled order', function() {
+    const standardTx = processRevolutTx(
+      makeOrder({
+        fees_partner_currency: {
+          partner_fee: { amount: 1.51, currency: 'USD' }
+        }
+      }),
+      pluginParams
+    )
+    expect(standardTx.revenueUsd).to.equal(1.51)
+    expect(standardTx.revenueSource).to.equal('reported')
+  })
+
+  it('records no revenue on an unsettled attempt even when a fee is present', function() {
+    // A failed attempt's fee is not revenue.
+    const standardTx = processRevolutTx(
+      makeOrder({
+        status: 'FAILED',
+        fees_partner_currency: {
+          partner_fee: { amount: 1.51, currency: 'USD' }
+        }
+      }),
+      pluginParams
+    )
+    expect(standardTx.revenueUsd).to.equal(undefined)
+    expect(standardTx.revenueSource).to.equal(undefined)
+  })
+
+  it('records no revenue when the settlement currency is not USD', function() {
+    // The plugin cannot convert honestly, so it abstains rather than guesses.
+    const standardTx = processRevolutTx(
+      makeOrder({
+        fees_partner_currency: {
+          partner_fee: { amount: 1.3, currency: 'EUR' }
+        }
+      }),
+      pluginParams
+    )
+    expect(standardTx.revenueUsd).to.equal(undefined)
+  })
+
+  it('records no revenue when the fee block is absent', function() {
+    const standardTx = processRevolutTx(makeOrder(), pluginParams)
+    expect(standardTx.revenueUsd).to.equal(undefined)
+    expect(standardTx.revenueSource).to.equal(undefined)
+  })
+
   it('throws on a structurally invalid order', function() {
     expect(() =>
       processRevolutTx({ id: 'no-amounts' }, pluginParams)

--- a/test/testData.json
+++ b/test/testData.json
@@ -1164,6 +1164,7 @@
           "isoDate": "2020-07-01T00:00:00.000Z",
           "usdValue": 18949.855647399967,
           "numTxs": 165,
+          "revenueUsd": 0,
           "currencyCodes": {
             "DOGE": 4353.434238976961,
             "ETH": 1039.0955238959054,
@@ -1319,6 +1320,7 @@
           "isoDate": "2011-03-01T00:00:00.000Z",
           "usdValue": 9520,
           "numTxs": 5,
+          "revenueUsd": 0,
           "currencyCodes": {
             "DOGE": 4760,
             "ETH": 220,
@@ -1339,6 +1341,7 @@
           "isoDate": "2011-03-13T00:00:00.000Z",
           "usdValue": 9480,
           "numTxs": 4,
+          "revenueUsd": 0,
           "currencyCodes": {
             "DOGE": 4740,
             "ETH": 200,
@@ -1356,6 +1359,7 @@
           "isoDate": "2011-03-14T00:00:00.000Z",
           "usdValue": 40,
           "numTxs": 1,
+          "revenueUsd": 0,
           "currencyCodes": {
             "ETH": 20,
             "DOGE": 20
@@ -1371,6 +1375,7 @@
           "isoDate": "2011-03-13T07:00:00.000Z",
           "usdValue": 2480,
           "numTxs": 3,
+          "revenueUsd": 0,
           "currencyCodes": {
             "DOGE": 1240,
             "ETH": 200,
@@ -1388,6 +1393,7 @@
           "isoDate": "2011-03-13T08:00:00.000Z",
           "usdValue": 0,
           "numTxs": 0,
+          "revenueUsd": 0,
           "currencyCodes": {},
           "currencyPairs": {}
         },
@@ -1396,6 +1402,7 @@
           "isoDate": "2011-03-13T09:00:00.000Z",
           "usdValue": 0,
           "numTxs": 0,
+          "revenueUsd": 0,
           "currencyCodes": {},
           "currencyPairs": {}
         },
@@ -1404,6 +1411,7 @@
           "isoDate": "2011-03-13T10:00:00.000Z",
           "usdValue": 7000,
           "numTxs": 1,
+          "revenueUsd": 0,
           "currencyCodes": {
             "BTC": 3500,
             "DOGE": 3500
@@ -1417,6 +1425,7 @@
           "isoDate": "2011-03-13T11:00:00.000Z",
           "usdValue": 0,
           "numTxs": 0,
+          "revenueUsd": 0,
           "currencyCodes": {},
           "currencyPairs": {}
         },
@@ -1425,6 +1434,7 @@
           "isoDate": "2011-03-13T12:00:00.000Z",
           "usdValue": 0,
           "numTxs": 0,
+          "revenueUsd": 0,
           "currencyCodes": {},
           "currencyPairs": {}
         },
@@ -1433,6 +1443,7 @@
           "isoDate": "2011-03-13T13:00:00.000Z",
           "usdValue": 0,
           "numTxs": 0,
+          "revenueUsd": 0,
           "currencyCodes": {},
           "currencyPairs": {}
         },
@@ -1441,6 +1452,7 @@
           "isoDate": "2011-03-13T14:00:00.000Z",
           "usdValue": 0,
           "numTxs": 0,
+          "revenueUsd": 0,
           "currencyCodes": {},
           "currencyPairs": {}
         },
@@ -1449,6 +1461,7 @@
           "isoDate": "2011-03-13T15:00:00.000Z",
           "usdValue": 0,
           "numTxs": 0,
+          "revenueUsd": 0,
           "currencyCodes": {},
           "currencyPairs": {}
         },
@@ -1457,6 +1470,7 @@
           "isoDate": "2011-03-13T16:00:00.000Z",
           "usdValue": 0,
           "numTxs": 0,
+          "revenueUsd": 0,
           "currencyCodes": {},
           "currencyPairs": {}
         },
@@ -1465,6 +1479,7 @@
           "isoDate": "2011-03-13T17:00:00.000Z",
           "usdValue": 0,
           "numTxs": 0,
+          "revenueUsd": 0,
           "currencyCodes": {},
           "currencyPairs": {}
         },
@@ -1473,6 +1488,7 @@
           "isoDate": "2011-03-13T18:00:00.000Z",
           "usdValue": 0,
           "numTxs": 0,
+          "revenueUsd": 0,
           "currencyCodes": {},
           "currencyPairs": {}
         },
@@ -1481,6 +1497,7 @@
           "isoDate": "2011-03-13T19:00:00.000Z",
           "usdValue": 0,
           "numTxs": 0,
+          "revenueUsd": 0,
           "currencyCodes": {},
           "currencyPairs": {}
         },
@@ -1489,6 +1506,7 @@
           "isoDate": "2011-03-13T20:00:00.000Z",
           "usdValue": 0,
           "numTxs": 0,
+          "revenueUsd": 0,
           "currencyCodes": {},
           "currencyPairs": {}
         },
@@ -1497,6 +1515,7 @@
           "isoDate": "2011-03-13T21:00:00.000Z",
           "usdValue": 0,
           "numTxs": 0,
+          "revenueUsd": 0,
           "currencyCodes": {},
           "currencyPairs": {}
         },
@@ -1505,6 +1524,7 @@
           "isoDate": "2011-03-13T22:00:00.000Z",
           "usdValue": 0,
           "numTxs": 0,
+          "revenueUsd": 0,
           "currencyCodes": {},
           "currencyPairs": {}
         },
@@ -1513,6 +1533,7 @@
           "isoDate": "2011-03-13T23:00:00.000Z",
           "usdValue": 0,
           "numTxs": 0,
+          "revenueUsd": 0,
           "currencyCodes": {},
           "currencyPairs": {}
         },
@@ -1521,6 +1542,7 @@
           "isoDate": "2011-03-14T00:00:00.000Z",
           "usdValue": 0,
           "numTxs": 0,
+          "revenueUsd": 0,
           "currencyCodes": {},
           "currencyPairs": {}
         },
@@ -1529,6 +1551,7 @@
           "isoDate": "2011-03-14T01:00:00.000Z",
           "usdValue": 0,
           "numTxs": 0,
+          "revenueUsd": 0,
           "currencyCodes": {},
           "currencyPairs": {}
         },
@@ -1537,6 +1560,7 @@
           "isoDate": "2011-03-14T02:00:00.000Z",
           "usdValue": 40,
           "numTxs": 1,
+          "revenueUsd": 0,
           "currencyCodes": {
             "ETH": 20,
             "DOGE": 20
@@ -1599,6 +1623,7 @@
           "isoDate": "2024-02-27T00:00:00.000Z",
           "usdValue": 9900.43,
           "numTxs": 1,
+          "revenueUsd": 0,
           "currencyCodes": {
             "BTC": 4950.215,
             "ETH": 4950.215
@@ -1612,6 +1637,7 @@
           "isoDate": "2024-02-28T00:00:00.000Z",
           "usdValue": 0,
           "numTxs": 0,
+          "revenueUsd": 0,
           "currencyCodes": {},
           "currencyPairs": {}
         },
@@ -1620,6 +1646,7 @@
           "isoDate": "2024-02-29T00:00:00.000Z",
           "usdValue": 20800,
           "numTxs": 2,
+          "revenueUsd": 0,
           "currencyCodes": {
             "BTC": 10400,
             "DOGE": 10400
@@ -1633,6 +1660,7 @@
           "isoDate": "2024-03-01T00:00:00.000Z",
           "usdValue": 2,
           "numTxs": 1,
+          "revenueUsd": 0,
           "currencyCodes": {
             "BTC": 1,
             "DOGE": 1
@@ -1646,6 +1674,7 @@
           "isoDate": "2024-03-02T00:00:00.000Z",
           "usdValue": 1000,
           "numTxs": 1,
+          "revenueUsd": 0,
           "currencyCodes": {
             "ETH": 500,
             "DOGE": 500
@@ -1659,6 +1688,7 @@
           "isoDate": "2024-03-03T00:00:00.000Z",
           "usdValue": 0,
           "numTxs": 0,
+          "revenueUsd": 0,
           "currencyCodes": {},
           "currencyPairs": {}
         }
@@ -1669,6 +1699,7 @@
           "isoDate": "2024-02-27T00:00:00.000Z",
           "usdValue": 0,
           "numTxs": 0,
+          "revenueUsd": 0,
           "currencyCodes": {},
           "currencyPairs": {}
         },
@@ -1677,6 +1708,7 @@
           "isoDate": "2024-02-27T01:00:00.000Z",
           "usdValue": 0,
           "numTxs": 0,
+          "revenueUsd": 0,
           "currencyCodes": {},
           "currencyPairs": {}
         },
@@ -1685,6 +1717,7 @@
           "isoDate": "2024-02-27T02:00:00.000Z",
           "usdValue": 9900.43,
           "numTxs": 1,
+          "revenueUsd": 0,
           "currencyCodes": {
             "BTC": 4950.215,
             "ETH": 4950.215
@@ -1698,6 +1731,7 @@
           "isoDate": "2024-02-27T03:00:00.000Z",
           "usdValue": 0,
           "numTxs": 0,
+          "revenueUsd": 0,
           "currencyCodes": {},
           "currencyPairs": {}
         },
@@ -1706,6 +1740,7 @@
           "isoDate": "2024-02-27T04:00:00.000Z",
           "usdValue": 0,
           "numTxs": 0,
+          "revenueUsd": 0,
           "currencyCodes": {},
           "currencyPairs": {}
         },
@@ -1714,6 +1749,7 @@
           "isoDate": "2024-02-27T05:00:00.000Z",
           "usdValue": 0,
           "numTxs": 0,
+          "revenueUsd": 0,
           "currencyCodes": {},
           "currencyPairs": {}
         },
@@ -1722,6 +1758,7 @@
           "isoDate": "2024-02-27T06:00:00.000Z",
           "usdValue": 0,
           "numTxs": 0,
+          "revenueUsd": 0,
           "currencyCodes": {},
           "currencyPairs": {}
         },
@@ -1730,6 +1767,7 @@
           "isoDate": "2024-02-27T07:00:00.000Z",
           "usdValue": 0,
           "numTxs": 0,
+          "revenueUsd": 0,
           "currencyCodes": {},
           "currencyPairs": {}
         },
@@ -1738,6 +1776,7 @@
           "isoDate": "2024-02-27T08:00:00.000Z",
           "usdValue": 0,
           "numTxs": 0,
+          "revenueUsd": 0,
           "currencyCodes": {},
           "currencyPairs": {}
         },
@@ -1746,6 +1785,7 @@
           "isoDate": "2024-02-27T09:00:00.000Z",
           "usdValue": 0,
           "numTxs": 0,
+          "revenueUsd": 0,
           "currencyCodes": {},
           "currencyPairs": {}
         },
@@ -1754,6 +1794,7 @@
           "isoDate": "2024-02-27T10:00:00.000Z",
           "usdValue": 0,
           "numTxs": 0,
+          "revenueUsd": 0,
           "currencyCodes": {},
           "currencyPairs": {}
         },
@@ -1762,6 +1803,7 @@
           "isoDate": "2024-02-27T11:00:00.000Z",
           "usdValue": 0,
           "numTxs": 0,
+          "revenueUsd": 0,
           "currencyCodes": {},
           "currencyPairs": {}
         },
@@ -1770,6 +1812,7 @@
           "isoDate": "2024-02-27T12:00:00.000Z",
           "usdValue": 0,
           "numTxs": 0,
+          "revenueUsd": 0,
           "currencyCodes": {},
           "currencyPairs": {}
         },
@@ -1778,6 +1821,7 @@
           "isoDate": "2024-02-27T13:00:00.000Z",
           "usdValue": 0,
           "numTxs": 0,
+          "revenueUsd": 0,
           "currencyCodes": {},
           "currencyPairs": {}
         },
@@ -1786,6 +1830,7 @@
           "isoDate": "2024-02-27T14:00:00.000Z",
           "usdValue": 0,
           "numTxs": 0,
+          "revenueUsd": 0,
           "currencyCodes": {},
           "currencyPairs": {}
         },
@@ -1794,6 +1839,7 @@
           "isoDate": "2024-02-27T15:00:00.000Z",
           "usdValue": 0,
           "numTxs": 0,
+          "revenueUsd": 0,
           "currencyCodes": {},
           "currencyPairs": {}
         },
@@ -1802,6 +1848,7 @@
           "isoDate": "2024-02-27T16:00:00.000Z",
           "usdValue": 0,
           "numTxs": 0,
+          "revenueUsd": 0,
           "currencyCodes": {},
           "currencyPairs": {}
         },
@@ -1810,6 +1857,7 @@
           "isoDate": "2024-02-27T17:00:00.000Z",
           "usdValue": 0,
           "numTxs": 0,
+          "revenueUsd": 0,
           "currencyCodes": {},
           "currencyPairs": {}
         },
@@ -1818,6 +1866,7 @@
           "isoDate": "2024-02-27T18:00:00.000Z",
           "usdValue": 0,
           "numTxs": 0,
+          "revenueUsd": 0,
           "currencyCodes": {},
           "currencyPairs": {}
         },
@@ -1826,6 +1875,7 @@
           "isoDate": "2024-02-27T19:00:00.000Z",
           "usdValue": 0,
           "numTxs": 0,
+          "revenueUsd": 0,
           "currencyCodes": {},
           "currencyPairs": {}
         },
@@ -1834,6 +1884,7 @@
           "isoDate": "2024-02-27T20:00:00.000Z",
           "usdValue": 0,
           "numTxs": 0,
+          "revenueUsd": 0,
           "currencyCodes": {},
           "currencyPairs": {}
         },
@@ -1842,6 +1893,7 @@
           "isoDate": "2024-02-27T21:00:00.000Z",
           "usdValue": 0,
           "numTxs": 0,
+          "revenueUsd": 0,
           "currencyCodes": {},
           "currencyPairs": {}
         },
@@ -1850,6 +1902,7 @@
           "isoDate": "2024-02-27T22:00:00.000Z",
           "usdValue": 0,
           "numTxs": 0,
+          "revenueUsd": 0,
           "currencyCodes": {},
           "currencyPairs": {}
         },
@@ -1858,6 +1911,7 @@
           "isoDate": "2024-02-27T23:00:00.000Z",
           "usdValue": 0,
           "numTxs": 0,
+          "revenueUsd": 0,
           "currencyCodes": {},
           "currencyPairs": {}
         },
@@ -1866,6 +1920,7 @@
           "isoDate": "2024-02-28T00:00:00.000Z",
           "usdValue": 0,
           "numTxs": 0,
+          "revenueUsd": 0,
           "currencyCodes": {},
           "currencyPairs": {}
         },
@@ -1874,6 +1929,7 @@
           "isoDate": "2024-02-28T01:00:00.000Z",
           "usdValue": 0,
           "numTxs": 0,
+          "revenueUsd": 0,
           "currencyCodes": {},
           "currencyPairs": {}
         },
@@ -1882,6 +1938,7 @@
           "isoDate": "2024-02-28T02:00:00.000Z",
           "usdValue": 0,
           "numTxs": 0,
+          "revenueUsd": 0,
           "currencyCodes": {},
           "currencyPairs": {}
         },
@@ -1890,6 +1947,7 @@
           "isoDate": "2024-02-28T03:00:00.000Z",
           "usdValue": 0,
           "numTxs": 0,
+          "revenueUsd": 0,
           "currencyCodes": {},
           "currencyPairs": {}
         },
@@ -1898,6 +1956,7 @@
           "isoDate": "2024-02-28T04:00:00.000Z",
           "usdValue": 0,
           "numTxs": 0,
+          "revenueUsd": 0,
           "currencyCodes": {},
           "currencyPairs": {}
         },
@@ -1906,6 +1965,7 @@
           "isoDate": "2024-02-28T05:00:00.000Z",
           "usdValue": 0,
           "numTxs": 0,
+          "revenueUsd": 0,
           "currencyCodes": {},
           "currencyPairs": {}
         },
@@ -1914,6 +1974,7 @@
           "isoDate": "2024-02-28T06:00:00.000Z",
           "usdValue": 0,
           "numTxs": 0,
+          "revenueUsd": 0,
           "currencyCodes": {},
           "currencyPairs": {}
         },
@@ -1922,6 +1983,7 @@
           "isoDate": "2024-02-28T07:00:00.000Z",
           "usdValue": 0,
           "numTxs": 0,
+          "revenueUsd": 0,
           "currencyCodes": {},
           "currencyPairs": {}
         },
@@ -1930,6 +1992,7 @@
           "isoDate": "2024-02-28T08:00:00.000Z",
           "usdValue": 0,
           "numTxs": 0,
+          "revenueUsd": 0,
           "currencyCodes": {},
           "currencyPairs": {}
         },
@@ -1938,6 +2001,7 @@
           "isoDate": "2024-02-28T09:00:00.000Z",
           "usdValue": 0,
           "numTxs": 0,
+          "revenueUsd": 0,
           "currencyCodes": {},
           "currencyPairs": {}
         },
@@ -1946,6 +2010,7 @@
           "isoDate": "2024-02-28T10:00:00.000Z",
           "usdValue": 0,
           "numTxs": 0,
+          "revenueUsd": 0,
           "currencyCodes": {},
           "currencyPairs": {}
         },
@@ -1954,6 +2019,7 @@
           "isoDate": "2024-02-28T11:00:00.000Z",
           "usdValue": 0,
           "numTxs": 0,
+          "revenueUsd": 0,
           "currencyCodes": {},
           "currencyPairs": {}
         },
@@ -1962,6 +2028,7 @@
           "isoDate": "2024-02-28T12:00:00.000Z",
           "usdValue": 0,
           "numTxs": 0,
+          "revenueUsd": 0,
           "currencyCodes": {},
           "currencyPairs": {}
         },
@@ -1970,6 +2037,7 @@
           "isoDate": "2024-02-28T13:00:00.000Z",
           "usdValue": 0,
           "numTxs": 0,
+          "revenueUsd": 0,
           "currencyCodes": {},
           "currencyPairs": {}
         },
@@ -1978,6 +2046,7 @@
           "isoDate": "2024-02-28T14:00:00.000Z",
           "usdValue": 0,
           "numTxs": 0,
+          "revenueUsd": 0,
           "currencyCodes": {},
           "currencyPairs": {}
         },
@@ -1986,6 +2055,7 @@
           "isoDate": "2024-02-28T15:00:00.000Z",
           "usdValue": 0,
           "numTxs": 0,
+          "revenueUsd": 0,
           "currencyCodes": {},
           "currencyPairs": {}
         },
@@ -1994,6 +2064,7 @@
           "isoDate": "2024-02-28T16:00:00.000Z",
           "usdValue": 0,
           "numTxs": 0,
+          "revenueUsd": 0,
           "currencyCodes": {},
           "currencyPairs": {}
         },
@@ -2002,6 +2073,7 @@
           "isoDate": "2024-02-28T17:00:00.000Z",
           "usdValue": 0,
           "numTxs": 0,
+          "revenueUsd": 0,
           "currencyCodes": {},
           "currencyPairs": {}
         },
@@ -2010,6 +2082,7 @@
           "isoDate": "2024-02-28T18:00:00.000Z",
           "usdValue": 0,
           "numTxs": 0,
+          "revenueUsd": 0,
           "currencyCodes": {},
           "currencyPairs": {}
         },
@@ -2018,6 +2091,7 @@
           "isoDate": "2024-02-28T19:00:00.000Z",
           "usdValue": 0,
           "numTxs": 0,
+          "revenueUsd": 0,
           "currencyCodes": {},
           "currencyPairs": {}
         },
@@ -2026,6 +2100,7 @@
           "isoDate": "2024-02-28T20:00:00.000Z",
           "usdValue": 0,
           "numTxs": 0,
+          "revenueUsd": 0,
           "currencyCodes": {},
           "currencyPairs": {}
         },
@@ -2034,6 +2109,7 @@
           "isoDate": "2024-02-28T21:00:00.000Z",
           "usdValue": 0,
           "numTxs": 0,
+          "revenueUsd": 0,
           "currencyCodes": {},
           "currencyPairs": {}
         },
@@ -2042,6 +2118,7 @@
           "isoDate": "2024-02-28T22:00:00.000Z",
           "usdValue": 0,
           "numTxs": 0,
+          "revenueUsd": 0,
           "currencyCodes": {},
           "currencyPairs": {}
         },
@@ -2050,6 +2127,7 @@
           "isoDate": "2024-02-28T23:00:00.000Z",
           "usdValue": 0,
           "numTxs": 0,
+          "revenueUsd": 0,
           "currencyCodes": {},
           "currencyPairs": {}
         },
@@ -2058,6 +2136,7 @@
           "isoDate": "2024-02-29T00:00:00.000Z",
           "usdValue": 0,
           "numTxs": 0,
+          "revenueUsd": 0,
           "currencyCodes": {},
           "currencyPairs": {}
         },
@@ -2066,6 +2145,7 @@
           "isoDate": "2024-02-29T01:00:00.000Z",
           "usdValue": 0,
           "numTxs": 0,
+          "revenueUsd": 0,
           "currencyCodes": {},
           "currencyPairs": {}
         },
@@ -2074,6 +2154,7 @@
           "isoDate": "2024-02-29T02:00:00.000Z",
           "usdValue": 0,
           "numTxs": 0,
+          "revenueUsd": 0,
           "currencyCodes": {},
           "currencyPairs": {}
         },
@@ -2082,6 +2163,7 @@
           "isoDate": "2024-02-29T03:00:00.000Z",
           "usdValue": 0,
           "numTxs": 0,
+          "revenueUsd": 0,
           "currencyCodes": {},
           "currencyPairs": {}
         },
@@ -2090,6 +2172,7 @@
           "isoDate": "2024-02-29T04:00:00.000Z",
           "usdValue": 0,
           "numTxs": 0,
+          "revenueUsd": 0,
           "currencyCodes": {},
           "currencyPairs": {}
         },
@@ -2098,6 +2181,7 @@
           "isoDate": "2024-02-29T05:00:00.000Z",
           "usdValue": 0,
           "numTxs": 0,
+          "revenueUsd": 0,
           "currencyCodes": {},
           "currencyPairs": {}
         },
@@ -2106,6 +2190,7 @@
           "isoDate": "2024-02-29T06:00:00.000Z",
           "usdValue": 0,
           "numTxs": 0,
+          "revenueUsd": 0,
           "currencyCodes": {},
           "currencyPairs": {}
         },
@@ -2114,6 +2199,7 @@
           "isoDate": "2024-02-29T07:00:00.000Z",
           "usdValue": 0,
           "numTxs": 0,
+          "revenueUsd": 0,
           "currencyCodes": {},
           "currencyPairs": {}
         },
@@ -2122,6 +2208,7 @@
           "isoDate": "2024-02-29T08:00:00.000Z",
           "usdValue": 0,
           "numTxs": 0,
+          "revenueUsd": 0,
           "currencyCodes": {},
           "currencyPairs": {}
         },
@@ -2130,6 +2217,7 @@
           "isoDate": "2024-02-29T09:00:00.000Z",
           "usdValue": 20800,
           "numTxs": 2,
+          "revenueUsd": 0,
           "currencyCodes": {
             "BTC": 10400,
             "DOGE": 10400
@@ -2143,6 +2231,7 @@
           "isoDate": "2024-02-29T10:00:00.000Z",
           "usdValue": 0,
           "numTxs": 0,
+          "revenueUsd": 0,
           "currencyCodes": {},
           "currencyPairs": {}
         },
@@ -2151,6 +2240,7 @@
           "isoDate": "2024-02-29T11:00:00.000Z",
           "usdValue": 0,
           "numTxs": 0,
+          "revenueUsd": 0,
           "currencyCodes": {},
           "currencyPairs": {}
         },
@@ -2159,6 +2249,7 @@
           "isoDate": "2024-02-29T12:00:00.000Z",
           "usdValue": 0,
           "numTxs": 0,
+          "revenueUsd": 0,
           "currencyCodes": {},
           "currencyPairs": {}
         },
@@ -2167,6 +2258,7 @@
           "isoDate": "2024-02-29T13:00:00.000Z",
           "usdValue": 0,
           "numTxs": 0,
+          "revenueUsd": 0,
           "currencyCodes": {},
           "currencyPairs": {}
         },
@@ -2175,6 +2267,7 @@
           "isoDate": "2024-02-29T14:00:00.000Z",
           "usdValue": 0,
           "numTxs": 0,
+          "revenueUsd": 0,
           "currencyCodes": {},
           "currencyPairs": {}
         },
@@ -2183,6 +2276,7 @@
           "isoDate": "2024-02-29T15:00:00.000Z",
           "usdValue": 0,
           "numTxs": 0,
+          "revenueUsd": 0,
           "currencyCodes": {},
           "currencyPairs": {}
         },
@@ -2191,6 +2285,7 @@
           "isoDate": "2024-02-29T16:00:00.000Z",
           "usdValue": 0,
           "numTxs": 0,
+          "revenueUsd": 0,
           "currencyCodes": {},
           "currencyPairs": {}
         },
@@ -2199,6 +2294,7 @@
           "isoDate": "2024-02-29T17:00:00.000Z",
           "usdValue": 0,
           "numTxs": 0,
+          "revenueUsd": 0,
           "currencyCodes": {},
           "currencyPairs": {}
         },
@@ -2207,6 +2303,7 @@
           "isoDate": "2024-02-29T18:00:00.000Z",
           "usdValue": 0,
           "numTxs": 0,
+          "revenueUsd": 0,
           "currencyCodes": {},
           "currencyPairs": {}
         },
@@ -2215,6 +2312,7 @@
           "isoDate": "2024-02-29T19:00:00.000Z",
           "usdValue": 0,
           "numTxs": 0,
+          "revenueUsd": 0,
           "currencyCodes": {},
           "currencyPairs": {}
         },
@@ -2223,6 +2321,7 @@
           "isoDate": "2024-02-29T20:00:00.000Z",
           "usdValue": 0,
           "numTxs": 0,
+          "revenueUsd": 0,
           "currencyCodes": {},
           "currencyPairs": {}
         },
@@ -2231,6 +2330,7 @@
           "isoDate": "2024-02-29T21:00:00.000Z",
           "usdValue": 0,
           "numTxs": 0,
+          "revenueUsd": 0,
           "currencyCodes": {},
           "currencyPairs": {}
         },
@@ -2239,6 +2339,7 @@
           "isoDate": "2024-02-29T22:00:00.000Z",
           "usdValue": 0,
           "numTxs": 0,
+          "revenueUsd": 0,
           "currencyCodes": {},
           "currencyPairs": {}
         },
@@ -2247,6 +2348,7 @@
           "isoDate": "2024-02-29T23:00:00.000Z",
           "usdValue": 0,
           "numTxs": 0,
+          "revenueUsd": 0,
           "currencyCodes": {},
           "currencyPairs": {}
         },
@@ -2255,6 +2357,7 @@
           "isoDate": "2024-03-01T00:00:00.000Z",
           "usdValue": 0,
           "numTxs": 0,
+          "revenueUsd": 0,
           "currencyCodes": {},
           "currencyPairs": {}
         },
@@ -2263,6 +2366,7 @@
           "isoDate": "2024-03-01T01:00:00.000Z",
           "usdValue": 0,
           "numTxs": 0,
+          "revenueUsd": 0,
           "currencyCodes": {},
           "currencyPairs": {}
         },
@@ -2271,6 +2375,7 @@
           "isoDate": "2024-03-01T02:00:00.000Z",
           "usdValue": 0,
           "numTxs": 0,
+          "revenueUsd": 0,
           "currencyCodes": {},
           "currencyPairs": {}
         },
@@ -2279,6 +2384,7 @@
           "isoDate": "2024-03-01T03:00:00.000Z",
           "usdValue": 0,
           "numTxs": 0,
+          "revenueUsd": 0,
           "currencyCodes": {},
           "currencyPairs": {}
         },
@@ -2287,6 +2393,7 @@
           "isoDate": "2024-03-01T04:00:00.000Z",
           "usdValue": 0,
           "numTxs": 0,
+          "revenueUsd": 0,
           "currencyCodes": {},
           "currencyPairs": {}
         },
@@ -2295,6 +2402,7 @@
           "isoDate": "2024-03-01T05:00:00.000Z",
           "usdValue": 2,
           "numTxs": 1,
+          "revenueUsd": 0,
           "currencyCodes": {
             "BTC": 1,
             "DOGE": 1
@@ -2308,6 +2416,7 @@
           "isoDate": "2024-03-01T06:00:00.000Z",
           "usdValue": 0,
           "numTxs": 0,
+          "revenueUsd": 0,
           "currencyCodes": {},
           "currencyPairs": {}
         },
@@ -2316,6 +2425,7 @@
           "isoDate": "2024-03-01T07:00:00.000Z",
           "usdValue": 0,
           "numTxs": 0,
+          "revenueUsd": 0,
           "currencyCodes": {},
           "currencyPairs": {}
         },
@@ -2324,6 +2434,7 @@
           "isoDate": "2024-03-01T08:00:00.000Z",
           "usdValue": 0,
           "numTxs": 0,
+          "revenueUsd": 0,
           "currencyCodes": {},
           "currencyPairs": {}
         },
@@ -2332,6 +2443,7 @@
           "isoDate": "2024-03-01T09:00:00.000Z",
           "usdValue": 0,
           "numTxs": 0,
+          "revenueUsd": 0,
           "currencyCodes": {},
           "currencyPairs": {}
         },
@@ -2340,6 +2452,7 @@
           "isoDate": "2024-03-01T10:00:00.000Z",
           "usdValue": 0,
           "numTxs": 0,
+          "revenueUsd": 0,
           "currencyCodes": {},
           "currencyPairs": {}
         },
@@ -2348,6 +2461,7 @@
           "isoDate": "2024-03-01T11:00:00.000Z",
           "usdValue": 0,
           "numTxs": 0,
+          "revenueUsd": 0,
           "currencyCodes": {},
           "currencyPairs": {}
         },
@@ -2356,6 +2470,7 @@
           "isoDate": "2024-03-01T12:00:00.000Z",
           "usdValue": 0,
           "numTxs": 0,
+          "revenueUsd": 0,
           "currencyCodes": {},
           "currencyPairs": {}
         },
@@ -2364,6 +2479,7 @@
           "isoDate": "2024-03-01T13:00:00.000Z",
           "usdValue": 0,
           "numTxs": 0,
+          "revenueUsd": 0,
           "currencyCodes": {},
           "currencyPairs": {}
         },
@@ -2372,6 +2488,7 @@
           "isoDate": "2024-03-01T14:00:00.000Z",
           "usdValue": 0,
           "numTxs": 0,
+          "revenueUsd": 0,
           "currencyCodes": {},
           "currencyPairs": {}
         },
@@ -2380,6 +2497,7 @@
           "isoDate": "2024-03-01T15:00:00.000Z",
           "usdValue": 0,
           "numTxs": 0,
+          "revenueUsd": 0,
           "currencyCodes": {},
           "currencyPairs": {}
         },
@@ -2388,6 +2506,7 @@
           "isoDate": "2024-03-01T16:00:00.000Z",
           "usdValue": 0,
           "numTxs": 0,
+          "revenueUsd": 0,
           "currencyCodes": {},
           "currencyPairs": {}
         },
@@ -2396,6 +2515,7 @@
           "isoDate": "2024-03-01T17:00:00.000Z",
           "usdValue": 0,
           "numTxs": 0,
+          "revenueUsd": 0,
           "currencyCodes": {},
           "currencyPairs": {}
         },
@@ -2404,6 +2524,7 @@
           "isoDate": "2024-03-01T18:00:00.000Z",
           "usdValue": 0,
           "numTxs": 0,
+          "revenueUsd": 0,
           "currencyCodes": {},
           "currencyPairs": {}
         },
@@ -2412,6 +2533,7 @@
           "isoDate": "2024-03-01T19:00:00.000Z",
           "usdValue": 0,
           "numTxs": 0,
+          "revenueUsd": 0,
           "currencyCodes": {},
           "currencyPairs": {}
         },
@@ -2420,6 +2542,7 @@
           "isoDate": "2024-03-01T20:00:00.000Z",
           "usdValue": 0,
           "numTxs": 0,
+          "revenueUsd": 0,
           "currencyCodes": {},
           "currencyPairs": {}
         },
@@ -2428,6 +2551,7 @@
           "isoDate": "2024-03-01T21:00:00.000Z",
           "usdValue": 0,
           "numTxs": 0,
+          "revenueUsd": 0,
           "currencyCodes": {},
           "currencyPairs": {}
         },
@@ -2436,6 +2560,7 @@
           "isoDate": "2024-03-01T22:00:00.000Z",
           "usdValue": 0,
           "numTxs": 0,
+          "revenueUsd": 0,
           "currencyCodes": {},
           "currencyPairs": {}
         },
@@ -2444,6 +2569,7 @@
           "isoDate": "2024-03-01T23:00:00.000Z",
           "usdValue": 0,
           "numTxs": 0,
+          "revenueUsd": 0,
           "currencyCodes": {},
           "currencyPairs": {}
         },
@@ -2452,6 +2578,7 @@
           "isoDate": "2024-03-02T00:00:00.000Z",
           "usdValue": 0,
           "numTxs": 0,
+          "revenueUsd": 0,
           "currencyCodes": {},
           "currencyPairs": {}
         },
@@ -2460,6 +2587,7 @@
           "isoDate": "2024-03-02T01:00:00.000Z",
           "usdValue": 0,
           "numTxs": 0,
+          "revenueUsd": 0,
           "currencyCodes": {},
           "currencyPairs": {}
         },
@@ -2468,6 +2596,7 @@
           "isoDate": "2024-03-02T02:00:00.000Z",
           "usdValue": 0,
           "numTxs": 0,
+          "revenueUsd": 0,
           "currencyCodes": {},
           "currencyPairs": {}
         },
@@ -2476,6 +2605,7 @@
           "isoDate": "2024-03-02T03:00:00.000Z",
           "usdValue": 0,
           "numTxs": 0,
+          "revenueUsd": 0,
           "currencyCodes": {},
           "currencyPairs": {}
         },
@@ -2484,6 +2614,7 @@
           "isoDate": "2024-03-02T04:00:00.000Z",
           "usdValue": 0,
           "numTxs": 0,
+          "revenueUsd": 0,
           "currencyCodes": {},
           "currencyPairs": {}
         },
@@ -2492,6 +2623,7 @@
           "isoDate": "2024-03-02T05:00:00.000Z",
           "usdValue": 0,
           "numTxs": 0,
+          "revenueUsd": 0,
           "currencyCodes": {},
           "currencyPairs": {}
         },
@@ -2500,6 +2632,7 @@
           "isoDate": "2024-03-02T06:00:00.000Z",
           "usdValue": 0,
           "numTxs": 0,
+          "revenueUsd": 0,
           "currencyCodes": {},
           "currencyPairs": {}
         },
@@ -2508,6 +2641,7 @@
           "isoDate": "2024-03-02T07:00:00.000Z",
           "usdValue": 0,
           "numTxs": 0,
+          "revenueUsd": 0,
           "currencyCodes": {},
           "currencyPairs": {}
         },
@@ -2516,6 +2650,7 @@
           "isoDate": "2024-03-02T08:00:00.000Z",
           "usdValue": 0,
           "numTxs": 0,
+          "revenueUsd": 0,
           "currencyCodes": {},
           "currencyPairs": {}
         },
@@ -2524,6 +2659,7 @@
           "isoDate": "2024-03-02T09:00:00.000Z",
           "usdValue": 0,
           "numTxs": 0,
+          "revenueUsd": 0,
           "currencyCodes": {},
           "currencyPairs": {}
         },
@@ -2532,6 +2668,7 @@
           "isoDate": "2024-03-02T10:00:00.000Z",
           "usdValue": 0,
           "numTxs": 0,
+          "revenueUsd": 0,
           "currencyCodes": {},
           "currencyPairs": {}
         },
@@ -2540,6 +2677,7 @@
           "isoDate": "2024-03-02T11:00:00.000Z",
           "usdValue": 0,
           "numTxs": 0,
+          "revenueUsd": 0,
           "currencyCodes": {},
           "currencyPairs": {}
         },
@@ -2548,6 +2686,7 @@
           "isoDate": "2024-03-02T12:00:00.000Z",
           "usdValue": 0,
           "numTxs": 0,
+          "revenueUsd": 0,
           "currencyCodes": {},
           "currencyPairs": {}
         },
@@ -2556,6 +2695,7 @@
           "isoDate": "2024-03-02T13:00:00.000Z",
           "usdValue": 0,
           "numTxs": 0,
+          "revenueUsd": 0,
           "currencyCodes": {},
           "currencyPairs": {}
         },
@@ -2564,6 +2704,7 @@
           "isoDate": "2024-03-02T14:00:00.000Z",
           "usdValue": 0,
           "numTxs": 0,
+          "revenueUsd": 0,
           "currencyCodes": {},
           "currencyPairs": {}
         },
@@ -2572,6 +2713,7 @@
           "isoDate": "2024-03-02T15:00:00.000Z",
           "usdValue": 0,
           "numTxs": 0,
+          "revenueUsd": 0,
           "currencyCodes": {},
           "currencyPairs": {}
         },
@@ -2580,6 +2722,7 @@
           "isoDate": "2024-03-02T16:00:00.000Z",
           "usdValue": 0,
           "numTxs": 0,
+          "revenueUsd": 0,
           "currencyCodes": {},
           "currencyPairs": {}
         },
@@ -2588,6 +2731,7 @@
           "isoDate": "2024-03-02T17:00:00.000Z",
           "usdValue": 0,
           "numTxs": 0,
+          "revenueUsd": 0,
           "currencyCodes": {},
           "currencyPairs": {}
         },
@@ -2596,6 +2740,7 @@
           "isoDate": "2024-03-02T18:00:00.000Z",
           "usdValue": 0,
           "numTxs": 0,
+          "revenueUsd": 0,
           "currencyCodes": {},
           "currencyPairs": {}
         },
@@ -2604,6 +2749,7 @@
           "isoDate": "2024-03-02T19:00:00.000Z",
           "usdValue": 0,
           "numTxs": 0,
+          "revenueUsd": 0,
           "currencyCodes": {},
           "currencyPairs": {}
         },
@@ -2612,6 +2758,7 @@
           "isoDate": "2024-03-02T20:00:00.000Z",
           "usdValue": 0,
           "numTxs": 0,
+          "revenueUsd": 0,
           "currencyCodes": {},
           "currencyPairs": {}
         },
@@ -2620,6 +2767,7 @@
           "isoDate": "2024-03-02T21:00:00.000Z",
           "usdValue": 0,
           "numTxs": 0,
+          "revenueUsd": 0,
           "currencyCodes": {},
           "currencyPairs": {}
         },
@@ -2628,6 +2776,7 @@
           "isoDate": "2024-03-02T22:00:00.000Z",
           "usdValue": 1000,
           "numTxs": 1,
+          "revenueUsd": 0,
           "currencyCodes": {
             "ETH": 500,
             "DOGE": 500
@@ -2641,6 +2790,7 @@
           "isoDate": "2024-03-02T23:00:00.000Z",
           "usdValue": 0,
           "numTxs": 0,
+          "revenueUsd": 0,
           "currencyCodes": {},
           "currencyPairs": {}
         },
@@ -2649,6 +2799,7 @@
           "isoDate": "2024-03-03T00:00:00.000Z",
           "usdValue": 0,
           "numTxs": 0,
+          "revenueUsd": 0,
           "currencyCodes": {},
           "currencyPairs": {}
         }
@@ -2684,6 +2835,7 @@
           "isoDate": "2022-12-01T00:00:00.000Z",
           "usdValue": 920,
           "numTxs": 1,
+          "revenueUsd": 0,
           "currencyCodes": {
             "ETH": 460,
             "BTC": 460
@@ -2697,6 +2849,7 @@
           "isoDate": "2023-01-01T00:00:00.000Z",
           "usdValue": 0,
           "numTxs": 0,
+          "revenueUsd": 0,
           "currencyCodes": {},
           "currencyPairs": {}
         },
@@ -2705,6 +2858,7 @@
           "isoDate": "2023-02-01T00:00:00.000Z",
           "usdValue": 0,
           "numTxs": 0,
+          "revenueUsd": 0,
           "currencyCodes": {},
           "currencyPairs": {}
         },
@@ -2713,6 +2867,7 @@
           "isoDate": "2023-03-01T00:00:00.000Z",
           "usdValue": 0,
           "numTxs": 0,
+          "revenueUsd": 0,
           "currencyCodes": {},
           "currencyPairs": {}
         },
@@ -2721,6 +2876,7 @@
           "isoDate": "2023-04-01T00:00:00.000Z",
           "usdValue": 0,
           "numTxs": 0,
+          "revenueUsd": 0,
           "currencyCodes": {},
           "currencyPairs": {}
         },
@@ -2729,6 +2885,7 @@
           "isoDate": "2023-05-01T00:00:00.000Z",
           "usdValue": 0,
           "numTxs": 0,
+          "revenueUsd": 0,
           "currencyCodes": {},
           "currencyPairs": {}
         },
@@ -2737,6 +2894,7 @@
           "isoDate": "2023-06-01T00:00:00.000Z",
           "usdValue": 0,
           "numTxs": 0,
+          "revenueUsd": 0,
           "currencyCodes": {},
           "currencyPairs": {}
         },
@@ -2745,6 +2903,7 @@
           "isoDate": "2023-07-01T00:00:00.000Z",
           "usdValue": 0,
           "numTxs": 0,
+          "revenueUsd": 0,
           "currencyCodes": {},
           "currencyPairs": {}
         },
@@ -2753,6 +2912,7 @@
           "isoDate": "2023-08-01T00:00:00.000Z",
           "usdValue": 0,
           "numTxs": 0,
+          "revenueUsd": 0,
           "currencyCodes": {},
           "currencyPairs": {}
         },
@@ -2761,6 +2921,7 @@
           "isoDate": "2023-09-01T00:00:00.000Z",
           "usdValue": 0,
           "numTxs": 0,
+          "revenueUsd": 0,
           "currencyCodes": {},
           "currencyPairs": {}
         },
@@ -2769,6 +2930,7 @@
           "isoDate": "2023-10-01T00:00:00.000Z",
           "usdValue": 0,
           "numTxs": 0,
+          "revenueUsd": 0,
           "currencyCodes": {},
           "currencyPairs": {}
         },
@@ -2777,6 +2939,7 @@
           "isoDate": "2023-11-01T00:00:00.000Z",
           "usdValue": 0,
           "numTxs": 0,
+          "revenueUsd": 0,
           "currencyCodes": {},
           "currencyPairs": {}
         },
@@ -2785,6 +2948,7 @@
           "isoDate": "2023-12-01T00:00:00.000Z",
           "usdValue": 0,
           "numTxs": 0,
+          "revenueUsd": 0,
           "currencyCodes": {},
           "currencyPairs": {}
         },
@@ -2793,6 +2957,7 @@
           "isoDate": "2024-01-01T00:00:00.000Z",
           "usdValue": 3,
           "numTxs": 1,
+          "revenueUsd": 0,
           "currencyCodes": {
             "BTC": 1.5,
             "DOGE": 1.5
@@ -2806,6 +2971,7 @@
           "isoDate": "2024-02-01T00:00:00.000Z",
           "usdValue": 0,
           "numTxs": 0,
+          "revenueUsd": 0,
           "currencyCodes": {},
           "currencyPairs": {}
         }


### PR DESCRIPTION
### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

none

### Description

Batched integration branch for the reports-server umbrella: the broken test suite is repaired first (everything else depends on it), then three partner plugins, then the isolated v2 dashboard and partner-reported revenue. One commit per unit of work.

Asana: https://app.asana.com/1/9976422036640/project/1213843652804305/task/1217040330890732

#### Commits

| Commit | What |
| --- | --- |
| `Fix broken mocha test suite` | Corrects the `util.test.ts` import and stale analytics fixtures so `npm test` passes. Unblocks every landing in this repo. |
| `Add CI job to run the test suite` | New `.github/workflows/test.yml` runs `npm test` on every PR, so the suite cannot silently rot again. |
| `Add Swapter partner plugin` | Supersedes partner PR #219 and our earlier recreation #224. |
| `Add NYM Swap (nymswap) reporting plugin` | New plugin, no prior PR. |
| `Add Revolut fiat payment provider` | Supersedes partner fork PR #211. |
| `Add v2 dashboard config endpoint and rev-share rates` | Isolated `GET /v2/config`. |
| `Add isolated v2 reports dashboard` | The `/v2/` dashboard itself. |
| `Track partner-reported revenue through to the dashboard` | `StandardTx.revenueUsd` / `revenueSource`, summed through the cache. |

Superseded PRs stay open until this lands: #211 and #219 are partner-owned fork branches (not ours to close), #224 is already closed.

Providers in scope but **not** in this branch: nexchange, Bridgeless, Simplex. They remain open on the umbrella.

#### v2 dashboard

**v1 is untouched.** v2 has its own entry point (`src/demoV2/`), its own parcel bundle (built into `dist/v2/` by a separate parcel invocation), and its own URL. v1's parcel `source`, routes, components and build output are unchanged. Shared v1 code is duplicated into v2 rather than refactored.

- **`src/demoV2/index.html`** — the full prototype UI (summary card; Providers and Currency pairs sections, each with a trend chart, a hover-linked donut + ranked-bar share card, and a detail table; global range/type/provider/pair filters; top-8-plus-Other color rules; paginated pair table). The rendering/interaction engine is ported verbatim; only the data layer changed.
- **Real API data** — on load the dashboard reads the `apiKey` cookie (or `?apiKey=`), validates via `GET /v1/getAppId`, then fetches `GET /v2/config`, `GET /v1/getPluginIds`, and one `POST /v1/analytics` (day buckets, last 24 months, all providers in a single call) and builds the per-provider daily series the engine consumes.
- **Auth = v1's apiKey model, minus the hang.** v1's known bug (`getAppId` returns plain text on a 400, `response.json()` throws, the mount promise dies silently and the page spins forever) is fixed: the response is checked before parsing and a bad/missing key redirects to a key-entry screen. No new auth system.
- **`src/routes/v2/getConfig.ts`** — new isolated `GET /v2/config` returning per-partner rev-share rates and fiat/swap classification. No v1 route is modified.
- **`src/demoV2/README.md`** — what v2 is, the endpoints it consumes, and local build/serve steps.

#### Revenue

Where a partner's API reports Edge's actual fee per order, the plugin stores it on the transaction as `revenueUsd` with `revenueSource: 'reported'`, the cache engine sums it into the analytics buckets, and the dashboard uses it directly, marked with a check in the provider table. That figure is a fact about the order and is never recomputed. Revolut is the first reporter (`fees_partner_currency.partner_fee`, taken only on settled orders and only when the settlement currency is USD).

Everywhere a partner reports nothing, the dashboard falls back to an estimate of `volume * revShareRate`, computed at read time. **Rates live on the `reports_apps` app doc**, beside each partner's `apiKeys`, not in `config.json`: the rate is a property of the app-partner deal, it is commercial terms, and this repo is public. A partner with no rate contributes 0. Correcting a rate fixes history immediately, while reported figures stay immutable.

Cache docs written before this change lack the revenue field until the next cache rebuild, which fills history from stored txs with no partner re-query.

#### Testing

`npm test` passes (and now runs in CI on every PR).

v2 verified end to end against a local CouchDB and the real API (`npm run build.dist` → `npm run start.api` → `/v2/`). See attached screenshots:

- Providers section rendering live data (summary tiles, top-8+Other stacked trend, sparklines).
- Currency pairs section + provider detail table (fiat/swap badges, share bars, per-pair charts, sparklines).
- Bad/missing apiKey redirects to the key-entry screen ("That API key was not recognized") instead of hanging.

Endpoint checks: `getAppId` valid→appId / invalid→400, `/v2/config` valid→JSON / invalid→401, `getPluginIds`→registered providers, `analytics` POST→expected bucket shape. `tsc` is clean; both v1 and v2 parcel bundles build. No browser console errors.

Note: the dashboard screenshots predate the revenue commit, so the provider table in them has no reported-revenue check column.
